### PR TITLE
fix: enable all custom formatters

### DIFF
--- a/src/pgrubic/core/loader.py
+++ b/src/pgrubic/core/loader.py
@@ -88,9 +88,7 @@ def load_formatters() -> set[typing.Callable[[], None]]:
 
         for _, formatter in inspect.getmembers(
             module,
-            lambda x: inspect.isfunction(x)
-            and x.__name__.endswith("_stmt")
-            and x.__module__ == module.__name__,  # noqa: B023
+            lambda x: inspect.isfunction(x) and x.__module__ == module.__name__,  # noqa: B023
         ):
             formatters.add(formatter)
 

--- a/src/pgrubic/core/loader.py
+++ b/src/pgrubic/core/loader.py
@@ -33,11 +33,13 @@ def load_rules(config: config.Config) -> set[linter.BaseChecker]:
     rules: set[linter.BaseChecker] = set()
 
     for path in sorted(RULES_DIRECTORY.rglob("[!_]*.py"), key=lambda x: x.name):
-        module = importlib.import_module(
+        module_path = (
             str(RULES_BASE_MODULE / path.relative_to(RULES_DIRECTORY))
             .replace(".py", "")
-            .replace(os.path.sep, "."),
+            .replace(os.path.sep, ".")
         )
+
+        module = importlib.import_module(module_path)
 
         for _, rule in inspect.getmembers(
             module,
@@ -76,11 +78,13 @@ def load_formatters() -> set[typing.Callable[[], None]]:
     formatters: set[typing.Callable[[], None]] = set()
 
     for path in sorted(FORMATTERS_DIRECTORY.rglob("[!_]*.py"), key=lambda x: x.name):
-        module = importlib.import_module(
+        module_path = (
             str(FORMATTERS_BASE_MODULE / path.relative_to(FORMATTERS_DIRECTORY))
             .replace(".py", "")
-            .replace(os.path.sep, "."),
+            .replace(os.path.sep, ".")
         )
+
+        module = importlib.import_module(module_path)
 
         for _, formatter in inspect.getmembers(
             module,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,7 +27,7 @@ def linter() -> core.Linter:
     return linter
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="session")
 def formatter() -> core.Formatter:
     """Setup formatters."""
     config: core.Config = core.parse_config()


### PR DESCRIPTION
- We use `importlib.import_module` to dynamically load formatters.
- Only formatters that end with `_stmt` https://github.com/bolajiwahab/pgrubic/blob/main/src/pgrubic/core/loader.py#L88 are expected to be loaded, this assumption was wrong because when `importlib.import_module` executes, it loads all the functions(formatters) and they are stored in memory. The side effect of this is that all formatters are loaded in single process even though we were limiting what formatters are to be loaded.
- When we enable multiprocessing https://github.com/bolajiwahab/pgrubic/pull/36 in the entry point, the above behaviour changed, now only explicitly added formatters are available within the child processes, this is due to the way multiprocessing works in python.
- Even though we test the entry point, we do not test it for all formatters and the tests there are simple tests, so this behaviour went unnoticed by tests.
- This PR enables every custom formatters by removing the filter.