### PR TITLE
docs: fix pglast github url

### DIFF
--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -28,5 +28,5 @@ A PostgreSQL linter and formatter for schema migrations and design best practice
 
 Pgrubic is built upon the shoulders of:
 
-- [pglast](https://github.com/pglast/pglast) - Python bindings to libpg_query
+- [pglast](https://github.com/lelit/pglast) - Python bindings to libpg_query
 - [libpg_query](https://github.com/pganalyze/libpg_query) - PostgreSQL parser outside of the server environment


### PR DESCRIPTION
In connection with https://github.com/bolajiwahab/pgrubic/pull/80, we also need to update `index.md` which is published at https://bolajiwahab.github.io/pgrubic/#requirements