### PR TITLE
fix: ignore semicolon in parentheses when building statement locations

### DIFF
--- a/src/pgrubic/core/noqa.py
+++ b/src/pgrubic/core/noqa.py
@@ -3,6 +3,7 @@
 import sys
 import typing
 import pathlib
+import dataclasses
 
 from pglast import parser
 from colorama import Fore, Style
@@ -162,14 +163,15 @@ def _get_statement_locations(
     return statement_start_location, statement_end_location
 
 
-class NoQaDirective(typing.NamedTuple):
+@dataclasses.dataclass(kw_only=True)
+class NoQaDirective:
     """Representation of a noqa directive."""
 
+    source_file: str | None = None
     location: int
     line_number: int
     column_offset: int
     rule: str
-    source_file: str | None = None
     used: bool = False
 
 

--- a/tests/fixtures/rules/general/GN002.yml
+++ b/tests/fixtures/rules/general/GN002.yml
@@ -7,6 +7,10 @@ test_fail_create_rule:
         ON UPDATE TO tbl
         DO ALSO NOTIFY tbl;
 
+test_fail_create_rule_multiple_statements:
+  sql_fail: |
+    CREATE RULE x AS ON SELECT TO tbl DO (SELECT 1; SELECT 2; SELECT 3;);
+
 test_pass_create_trigger:
   sql_pass: |
     CREATE OR REPLACE TRIGGER check_update


### PR DESCRIPTION
- Ignore semicolon in parentheses when building statement locations