### PR TITLE
feat: implement graceful exit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -208,7 +208,7 @@ legacy_tox_ini = """
     setenv = {[testenv:coverage]setenv}
     commands =
         coverage erase
-        coverage run -m pytest -vv {posargs:tests}
+        coverage run -m pytest -vv --color=yes {posargs:tests}
 
     [testenv:tests-linux]
     platform = linux

--- a/src/pgrubic/__init__.py
+++ b/src/pgrubic/__init__.py
@@ -14,6 +14,10 @@ WORKERS_ENVIRONMENT_VARIABLE: typing.Final[str] = f"{PACKAGE_NAME.upper()}_WORKE
 
 DEFAULT_WORKERS: typing.Final[int] = 4
 
+REPOSITORY_URL: typing.Final[str] = "https://github.com/bolajiwahab/pgrubic"
+
+ISSUES_URL: typing.Final[str] = f"{REPOSITORY_URL}/issues"
+
 DOCUMENTATION_URL: typing.Final[str] = "https://bolajiwahab.github.io/pgrubic"
 
 PACKAGE_DIRECTORY: typing.Final[pathlib.Path] = pathlib.Path(__file__).resolve().parent

--- a/src/pgrubic/__main__.py
+++ b/src/pgrubic/__main__.py
@@ -66,7 +66,7 @@ def cli() -> None:
 )
 @common_options
 @click.argument("sources", nargs=-1, type=click.Path(exists=True, path_type=pathlib.Path))  # type: ignore [type-var]
-def lint(  # noqa: C901, PLR0912, PLR0913
+def lint(  # noqa: C901, PLR0913
     sources: tuple[pathlib.Path, ...],
     *,
     fix: bool,
@@ -112,10 +112,6 @@ def lint(  # noqa: C901, PLR0912, PLR0913
     for rule in rules:
         linter.checkers.add(rule())
 
-    total_violations = 0
-    auto_fixable_violations = 0
-    fix_enabled_violations = 0
-
     # Use the current working directory if no sources are specified
     if not sources:
         sources = (pathlib.Path.cwd(),)
@@ -150,25 +146,25 @@ def lint(  # noqa: C901, PLR0912, PLR0913
             workers,
         ),
     ) as pool:
-        try:
-            results = [
-                pool.apply_async(
-                    linter.run,
-                    kwds={
-                        "source_file": source.resolve(),
-                        "source_code": source.read_text(encoding="utf-8"),
-                    },
-                )
-                for source in included_sources
-            ]
-            pool.close()
-            pool.join()
+        results = [
+            pool.apply_async(
+                linter.run,
+                kwds={
+                    "source_file": source.resolve(),
+                    "source_code": source.read_text(encoding="utf-8"),
+                },
+            )
+            for source in included_sources
+        ]
+        pool.close()
+        pool.join()
 
-            lint_results = [result.get() for result in results]
+        lint_results = [result.get() for result in results]
 
-        except errors.ParseError as error:
-            core.logger.error(error)
-            sys.exit(2)
+    total_violations = 0
+    auto_fixable_violations = 0
+    fix_enabled_violations = 0
+    total_errors = 0
 
     for lint_result in lint_results:
         violations = linter.get_violation_stats(
@@ -180,32 +176,40 @@ def lint(  # noqa: C901, PLR0912, PLR0913
             source_file=lint_result.source_file,
         )
 
+        errors.print_errors(
+            errors=lint_result.errors,
+            source_file=lint_result.source_file,
+        )
+
         total_violations += violations.total
         auto_fixable_violations += violations.auto_fixable
         fix_enabled_violations += violations.fix_enabled
+        total_errors += len(lint_result.errors)
 
-        if lint_result.fixed_sql:
+        if lint_result.fixed_source_code:
             with pathlib.Path(lint_result.source_file).open(
                 "w",
                 encoding="utf-8",
             ) as sf:
-                sf.write(lint_result.fixed_sql)
+                sf.write(lint_result.fixed_source_code)
 
-    if total_violations > 0:
+    if total_violations > 0 or total_errors > 0:
         if config.lint.fix:
             sys.stdout.write(
-                f"Found {total_violations} violation(s)"
+                f"\nFound {total_violations} violation(s)"
                 f" ({fix_enabled_violations} fixed,"
-                f" {total_violations - fix_enabled_violations} remaining)\n",
+                f" {total_violations - fix_enabled_violations} remaining)\n"
+                f"{total_errors} error(s) found\n",
             )
 
-            if (total_violations - fix_enabled_violations) > 0:
+            if (total_violations - fix_enabled_violations) > 0 or total_errors > 0:
                 sys.exit(1)
 
         else:
             sys.stdout.write(
-                f"Found {total_violations} violation(s)\n"
-                f"{auto_fixable_violations} fix(es) available, {fix_enabled_violations} fix(es) enabled\n",  # noqa: E501
+                f"\nFound {total_violations} violation(s)\n"
+                f"{auto_fixable_violations} fix(es) available, {fix_enabled_violations} fix(es) enabled\n"  # noqa: E501
+                f"{total_errors} error(s) found\n",
             )
 
             if auto_fixable_violations > 0:
@@ -239,7 +243,7 @@ def lint(  # noqa: C901, PLR0912, PLR0913
 )
 @common_options
 @click.argument("sources", nargs=-1, type=click.Path(exists=True, path_type=pathlib.Path))  # type: ignore [type-var]
-def format_sources(  # noqa: C901, PLR0913
+def format_sources(  # noqa: C901, PLR0913, PLR0912
     sources: tuple[pathlib.Path, ...],
     *,
     check: bool,
@@ -325,26 +329,22 @@ def format_sources(  # noqa: C901, PLR0913
             workers,
         ),
     ) as pool:
-        try:
-            results = [
-                pool.apply_async(
-                    formatter.format,
-                    kwds={
-                        "source_file": source.resolve(),
-                        "source_code": source.read_text(encoding="utf-8"),
-                    },
-                )
-                for source in included_sources
-            ]
-            pool.close()
-            pool.join()
+        results = [
+            pool.apply_async(
+                formatter.format,
+                kwds={
+                    "source_file": source.resolve(),
+                    "source_code": source.read_text(encoding="utf-8"),
+                },
+            )
+            for source in included_sources
+        ]
+        pool.close()
+        pool.join()
 
-            formatting_results = [result.get() for result in results]
+        formatting_results = [result.get() for result in results]
 
-        except (errors.ParseError, errors.MissingStatementTerminatorError) as error:
-            core.logger.error(error)
-            sys.exit(2)
-
+    total_errors = 0
     for formatting_result in formatting_results:
         if (
             formatting_result.formatted_source_code
@@ -373,14 +373,28 @@ def format_sources(  # noqa: C901, PLR0913
             ) as sf:
                 sf.write(formatting_result.formatted_source_code)
 
+        errors.print_errors(
+            errors=formatting_result.errors,
+            source_file=formatting_result.source_file,
+        )
+
+        total_errors += len(formatting_result.errors)
+
     if not config.format.check and not config.format.diff:
         cache.write(sources=included_sources)
         sys.stdout.write(
-            f"{len(sources_to_reformat)} file(s) reformatted, "
+            f"\n{len(sources_to_reformat)} file(s) reformatted, "
             f"{len(included_sources) - len(sources_to_reformat)} file(s) left unchanged\n",  # noqa: E501
         )
+        if total_errors > 0:
+            sys.stdout.write(f"{total_errors} error(s) found\n")
+            sys.exit(1)
 
-    if changes_detected and (config.format.check or config.format.diff):
+    if (
+        changes_detected and (config.format.check or config.format.diff)
+    ) or total_errors > 0:
+        if total_errors > 0:
+            sys.stdout.write(f"\n{total_errors} error(s) found\n")
         sys.exit(1)
 
 

--- a/src/pgrubic/__main__.py
+++ b/src/pgrubic/__main__.py
@@ -29,13 +29,13 @@ def common_options(func: abc.Callable[..., T]) -> abc.Callable[..., T]:
 @click.group(
     context_settings={"help_option_names": ["-h", "--help"]},
     epilog=f"""
-Examples:\n
-   {PACKAGE_NAME} lint\n
-   {PACKAGE_NAME} lint .\n
-   {PACKAGE_NAME} lint *.sql\n
-   {PACKAGE_NAME} lint example.sql\n
-   {PACKAGE_NAME} format file.sql\n
-   {PACKAGE_NAME} format migrations/\n
+Examples:{noqa.NEW_LINE}
+   {PACKAGE_NAME} lint{noqa.NEW_LINE}
+   {PACKAGE_NAME} lint .{noqa.NEW_LINE}
+   {PACKAGE_NAME} lint *.sql{noqa.NEW_LINE}
+   {PACKAGE_NAME} lint example.sql{noqa.NEW_LINE}
+   {PACKAGE_NAME} format file.sql{noqa.NEW_LINE}
+   {PACKAGE_NAME} format migrations/{noqa.NEW_LINE}
 """,
 )
 @click.version_option()
@@ -66,7 +66,7 @@ def cli() -> None:
 )
 @common_options
 @click.argument("sources", nargs=-1, type=click.Path(exists=True, path_type=pathlib.Path))  # type: ignore [type-var]
-def lint(  # noqa: C901, PLR0913
+def lint(  # noqa: C901, PLR0912, PLR0913
     sources: tuple[pathlib.Path, ...],
     *,
     fix: bool,
@@ -126,8 +126,9 @@ def lint(  # noqa: C901, PLR0913
     if add_file_level_general_noqa:
         sources_modified = noqa.add_file_level_general_ignore(included_sources)
         sys.stdout.write(
-            f"File-level general noqa directive added to {sources_modified} file(s)\n",
+            f"File-level general noqa directive added to {sources_modified} file(s){noqa.NEW_LINE}",  # noqa: E501
         )
+        sys.exit(0)
 
     # the `--workers` flag when provided, takes precedence over the environment variable
     # the environment variable when provided, takes precedence over the default
@@ -196,10 +197,10 @@ def lint(  # noqa: C901, PLR0913
     if total_violations > 0 or total_errors > 0:
         if config.lint.fix:
             sys.stdout.write(
-                f"\nFound {total_violations} violation(s)"
-                f" ({fix_enabled_violations} fixed,"
-                f" {total_violations - fix_enabled_violations} remaining)\n"
-                f"{total_errors} error(s) found\n",
+                f"{noqa.NEW_LINE}Found {total_violations} violation(s)"
+                f"{noqa.SPACE}({fix_enabled_violations} fixed,"
+                f"{noqa.SPACE}{total_violations - fix_enabled_violations} remaining){noqa.NEW_LINE}"  # noqa: E501
+                f"{total_errors} error(s) found{noqa.NEW_LINE}",
             )
 
             if (total_violations - fix_enabled_violations) > 0 or total_errors > 0:
@@ -207,17 +208,19 @@ def lint(  # noqa: C901, PLR0913
 
         else:
             sys.stdout.write(
-                f"\nFound {total_violations} violation(s)\n"
-                f"{auto_fixable_violations} fix(es) available, {fix_enabled_violations} fix(es) enabled\n"  # noqa: E501
-                f"{total_errors} error(s) found\n",
+                f"{noqa.NEW_LINE}Found {total_violations} violation(s){noqa.NEW_LINE}"
+                f"{auto_fixable_violations} fix(es) available, {fix_enabled_violations} fix(es) enabled{noqa.NEW_LINE}"  # noqa: E501
+                f"{total_errors} error(s) found{noqa.NEW_LINE}",
             )
 
             if auto_fixable_violations > 0:
                 sys.stdout.write(
-                    "Use with '--fix' to auto fix the violations\n",
+                    f"Use with '--fix' to auto fix the violations{noqa.NEW_LINE}",
                 )
 
             sys.exit(1)
+    else:
+        sys.stdout.write(f"All checks passed!{noqa.NEW_LINE}")
 
 
 @cli.command(name="format")
@@ -243,7 +246,7 @@ def lint(  # noqa: C901, PLR0913
 )
 @common_options
 @click.argument("sources", nargs=-1, type=click.Path(exists=True, path_type=pathlib.Path))  # type: ignore [type-var]
-def format_sources(  # noqa: C901, PLR0913, PLR0912
+def format_sources(  # noqa: C901, PLR0912, PLR0913
     sources: tuple[pathlib.Path, ...],
     *,
     check: bool,
@@ -310,8 +313,6 @@ def format_sources(  # noqa: C901, PLR0913, PLR0912
             sources=included_sources,
         )
 
-    changes_detected = False
-
     # the `--workers` flag when specified, takes precedence over the environment variable
     # the environment variable when provided, takes precedence over the default
     workers = (
@@ -344,7 +345,9 @@ def format_sources(  # noqa: C901, PLR0913, PLR0912
 
         formatting_results = [result.get() for result in results]
 
+    changes_detected = False
     total_errors = 0
+
     for formatting_result in formatting_results:
         if (
             formatting_result.formatted_source_code
@@ -383,18 +386,22 @@ def format_sources(  # noqa: C901, PLR0913, PLR0912
     if not config.format.check and not config.format.diff:
         cache.write(sources=included_sources)
         sys.stdout.write(
-            f"\n{len(sources_to_reformat)} file(s) reformatted, "
-            f"{len(included_sources) - len(sources_to_reformat)} file(s) left unchanged\n",  # noqa: E501
+            f"{noqa.NEW_LINE}{len(sources_to_reformat)} file(s) reformatted, "
+            f"{len(included_sources) - len(sources_to_reformat)} file(s) left unchanged{noqa.NEW_LINE}",  # noqa: E501
         )
         if total_errors > 0:
-            sys.stdout.write(f"{total_errors} error(s) found\n")
+            sys.stdout.write(f"{total_errors} error(s) found{noqa.NEW_LINE}")
             sys.exit(1)
+
+        sys.exit(0)
 
     if (
         changes_detected and (config.format.check or config.format.diff)
     ) or total_errors > 0:
         if total_errors > 0:
-            sys.stdout.write(f"\n{total_errors} error(s) found\n")
+            sys.stdout.write(
+                f"{noqa.NEW_LINE}{total_errors} error(s) found{noqa.NEW_LINE}",
+            )
         sys.exit(1)
 
 

--- a/src/pgrubic/core/__init__.py
+++ b/src/pgrubic/core/__init__.py
@@ -16,8 +16,6 @@ __all__ = [
     "Formatter",
     "Linter",
     "ViolationStats",
-    "add_apply_fix_to_rule",
-    "add_set_locations_to_rule",
     "cache",
     "config",
     "filter_sources",

--- a/src/pgrubic/core/errors.py
+++ b/src/pgrubic/core/errors.py
@@ -8,22 +8,6 @@ from colorama import Fore, Style
 from pgrubic.core import noqa
 
 
-class BaseError(Exception):
-    """Base class for all exceptions."""
-
-
-class MissingConfigError(BaseError):
-    """Raised when a config is missing."""
-
-
-class ParseError(BaseError):
-    """Raised when a parse error occurs."""
-
-
-class MissingStatementTerminatorError(BaseError):
-    """Raised when a statement terminator is missing."""
-
-
 class Error(typing.NamedTuple):
     """Representation of an error."""
 

--- a/src/pgrubic/core/errors.py
+++ b/src/pgrubic/core/errors.py
@@ -1,5 +1,12 @@
 """pgrubic errors."""
 
+import sys
+import typing
+
+from colorama import Fore, Style
+
+from pgrubic.core import noqa
+
 
 class BaseError(Exception):
     """Base class for all exceptions."""
@@ -15,3 +22,51 @@ class ParseError(BaseError):
 
 class MissingStatementTerminatorError(BaseError):
     """Raised when a statement terminator is missing."""
+
+
+class Error(typing.NamedTuple):
+    """Representation of an error."""
+
+    source_file: str
+    source_code: str
+    statement_start_location: int
+    statement_end_location: int
+    statement: str
+    message: str
+    hint: str
+
+
+def print_errors(
+    *,
+    errors: set[Error],
+    source_file: str,
+) -> None:
+    """Print all errors collected during linting.
+
+    Parameters:
+    ----------
+    errors: set[errors.Error]
+        Errors to print.
+    source_file: str
+        Path to the source file.
+
+    Returns:
+    -------
+    None
+    """
+    for error in errors:
+        sys.stdout.write(
+            f"{noqa.NEW_LINE}{source_file}: {error.message}: {error.hint}",
+        )
+
+        line_number = (
+            error.source_code[: error.statement_end_location].count(noqa.NEW_LINE) + 1
+        )
+
+        for idx, line in enumerate(
+            error.statement.splitlines(keepends=False),
+            start=line_number - error.statement.count(noqa.NEW_LINE),
+        ):
+            sys.stdout.write(
+                f"{Fore.BLUE}{idx} | {Style.RESET_ALL}{Fore.RED}{Style.BRIGHT}{line}{Style.RESET_ALL}{noqa.NEW_LINE}",  # noqa: E501
+            )

--- a/src/pgrubic/core/errors.py
+++ b/src/pgrubic/core/errors.py
@@ -8,6 +8,14 @@ from colorama import Fore, Style
 from pgrubic.core import noqa
 
 
+class BaseError(Exception):
+    """Base class for all exceptions."""
+
+
+class MissingConfigError(BaseError):
+    """Raised when a config is missing."""
+
+
 class Error(typing.NamedTuple):
     """Representation of an error."""
 

--- a/src/pgrubic/core/formatter.py
+++ b/src/pgrubic/core/formatter.py
@@ -48,7 +48,7 @@ class Formatter:
 
         Returns:
         -------
-        str
+        tuple[str, set[errors.Error]]
             Formatted source code.
         """
         _errors: set[errors.Error] = set()
@@ -97,7 +97,7 @@ class Formatter:
                         statement_end_location=statement.end_location,
                         statement=statement.text,
                         message=str(error),
-                        hint=f"""Make sure the statement is valid PostgreSQL statement. If it is, please report this issue at {ISSUES_URL}\n""",  # noqa: E501
+                        hint=f"""Make sure the statement is valid PostgreSQL statement. If it is, please report this issue at {ISSUES_URL}{noqa.NEW_LINE}""",  # noqa: E501
                     ),
                 )
                 formatted_statements.append(statement.text)

--- a/src/pgrubic/core/formatter.py
+++ b/src/pgrubic/core/formatter.py
@@ -56,12 +56,10 @@ class Formatter:
         formatted_statements: list[str] = []
 
         format_ignores = noqa.extract_format_ignores(
-            source_file=source_file,
             source_code=source_code,
         )
 
         for statement in noqa.extract_statement_locations(
-            source_file=source_file,
             source_code=source_code,
         ):
             if statement.start_location in format_ignores:
@@ -69,7 +67,6 @@ class Formatter:
                 continue
 
             comments = noqa.extract_comments(
-                source_file=source_file,
                 source_code=statement.text,
             )
 

--- a/src/pgrubic/core/formatter.py
+++ b/src/pgrubic/core/formatter.py
@@ -87,6 +87,7 @@ class Formatter:
                     formatted_statement += noqa.SEMI_COLON
 
                 formatted_statements.append(formatted_statement)
+
             except parser.ParseError as error:
                 _errors.add(
                     errors.Error(
@@ -100,7 +101,20 @@ class Formatter:
                     ),
                 )
                 formatted_statements.append(statement.text)
-                continue
+
+            except RecursionError as error:  # pragma: no cover
+                _errors.add(
+                    errors.Error(
+                        source_file=str(source_file),
+                        source_code=statement.text,
+                        statement_start_location=statement.start_location + 1,
+                        statement_end_location=statement.end_location,
+                        statement=statement.text,
+                        message=str(error),
+                        hint="Maximum format depth exceeded, reduce deeply nested queries",  # noqa: E501
+                    ),
+                )
+                formatted_statements.append(statement.text)
 
         return (
             noqa.NEW_LINE + (noqa.NEW_LINE * config.format.lines_between_statements)

--- a/src/pgrubic/core/formatter.py
+++ b/src/pgrubic/core/formatter.py
@@ -59,7 +59,7 @@ class Formatter:
             source_code=source_code,
         )
 
-        for statement in noqa.extract_statement_locations(
+        for statement in noqa.extract_statements(
             source_code=source_code,
         ):
             if statement.start_location in format_ignores:

--- a/src/pgrubic/core/linter.py
+++ b/src/pgrubic/core/linter.py
@@ -334,8 +334,8 @@ class Linter:
         for violation in violations:
             sys.stdout.write(
                 f"{noqa.NEW_LINE}{source_file}:{violation.line_number}:{violation.column_offset}:"
-                f" \033]8;;{DOCUMENTATION_URL}/rules/{violation.rule_category}/{violation.rule_name}{Style.RESET_ALL}\033\\{Fore.RED}{Style.BRIGHT}{violation.rule_code}{Style.RESET_ALL}\033]8;;\033\\:"  # noqa: E501
-                f" {violation.description}{noqa.NEW_LINE}",
+                f"{noqa.SPACE}\033]8;;{DOCUMENTATION_URL}/rules/{violation.rule_category}/{violation.rule_name}{Style.RESET_ALL}\033\\{Fore.RED}{Style.BRIGHT}{violation.rule_code}{Style.RESET_ALL}\033]8;;\033\\:"
+                f"{noqa.SPACE}{violation.description}{noqa.NEW_LINE}",
             )
 
             for idx, line in enumerate(
@@ -350,7 +350,7 @@ class Linter:
                 # used above between the separator (|)
                 (
                     sys.stdout.write(
-                        " "
+                        noqa.SPACE
                         * (violation.column_offset + len(str(violation.line_number)) + 2)
                         + "^"
                         + noqa.NEW_LINE,
@@ -390,14 +390,12 @@ class Linter:
         BaseChecker.config = self.config
 
         for statement in noqa.extract_statement_locations(
-            source_file=source_file,
             source_code=source_code,
         ):
             try:
                 parse_tree: ast.Node = parser.parse_sql(statement.text)
 
                 comments = noqa.extract_comments(
-                    source_file=source_file,
                     source_code=statement.text,
                 )
 

--- a/src/pgrubic/core/linter.py
+++ b/src/pgrubic/core/linter.py
@@ -415,7 +415,7 @@ class Linter:
                         statement_end_location=statement.end_location,
                         statement=statement.text,
                         message=str(error),
-                        hint=f"""Make sure the statement is valid PostgreSQL statement. If it is, please report this issue at {ISSUES_URL}\n""",  # noqa: E501
+                        hint=f"""Make sure the statement is valid PostgreSQL statement. If it is, please report this issue at {ISSUES_URL}{noqa.NEW_LINE}""",  # noqa: E501
                     ),
                 )
                 fixed_statements.append(statement.text)

--- a/src/pgrubic/core/linter.py
+++ b/src/pgrubic/core/linter.py
@@ -142,7 +142,7 @@ class CheckerMeta(type):
 
             result = func(checker, *args, **kwargs)
 
-            checker.applied_fixes.append(result is not None)
+            checker.applied_fixes.append(True)
 
             return result
 
@@ -175,7 +175,7 @@ class BaseChecker(visitors.Visitor, metaclass=CheckerMeta):  # type: ignore[misc
     line: str
 
     # Track applied fixes
-    applied_fixes: typing.ClassVar[list[bool]] = []
+    applied_fixes: list[bool]
 
     def __init__(self) -> None:
         """Initialize variables."""
@@ -423,6 +423,8 @@ class Linter:
 
             BaseChecker.statement = statement.text
             BaseChecker.statement_location = statement.start_location
+            # Reset the applied fixes for each statement
+            BaseChecker.applied_fixes = []
 
             for checker in self.checkers:
                 checker.violations = set()

--- a/src/pgrubic/core/linter.py
+++ b/src/pgrubic/core/linter.py
@@ -396,7 +396,7 @@ class Linter:
         BaseChecker.source_file = source_file
         BaseChecker.config = self.config
 
-        for statement in noqa.extract_statement_locations(
+        for statement in noqa.extract_statements(
             source_code=source_code,
         ):
             try:

--- a/src/pgrubic/core/linter.py
+++ b/src/pgrubic/core/linter.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import sys
-import copy
 import typing
 import fnmatch
 import functools
@@ -12,7 +11,7 @@ from pglast import ast, parser, stream, visitors
 from colorama import Fore, Style
 from caseconverter import kebabcase
 
-from pgrubic import DOCUMENTATION_URL
+from pgrubic import ISSUES_URL, DOCUMENTATION_URL
 from pgrubic.core import noqa, config, errors, formatter
 
 if typing.TYPE_CHECKING:
@@ -40,7 +39,8 @@ class LintResult(typing.NamedTuple):
 
     source_file: str
     violations: set[Violation]
-    fixed_sql: str | None = None
+    errors: set[errors.Error]
+    fixed_source_code: str | None = None
 
 
 class ViolationStats(typing.NamedTuple):
@@ -53,7 +53,8 @@ class ViolationStats(typing.NamedTuple):
 
 class CheckerMeta(type):
     """Metaclass for Checker. This metaclass handles both runtime and subclass method
-    decorations. It is originally created for method decorations but could be extended in
+    decorations ensuring decorated methods retain their decoration even in child
+    processes. It is originally created for method decorations but could be extended in
     the future.
     """
 
@@ -114,7 +115,7 @@ class CheckerMeta(type):
             if hasattr(node, "location") and isinstance(node.location, int):
                 checker.line = checker.source_code[line_start:line_end]
             else:
-                checker.line = checker.statement.strip()
+                checker.line = checker.statement
 
             return func(checker, ancestors, node)
 
@@ -179,7 +180,7 @@ class BaseChecker(visitors.Visitor, metaclass=CheckerMeta):  # type: ignore[misc
         cls.name = kebabcase(cls.__name__)
         cls.category = cls.__module__.split(".")[-2]
 
-    def visit(self, node: ast.Node, ancestors: visitors.Ancestor) -> None:
+    def visit(self, ancestors: visitors.Ancestor, node: ast.Node) -> None:
         """Visit the node."""
 
     @property
@@ -331,7 +332,6 @@ class Linter:
         None
         """
         for violation in violations:
-            # if not checker.is_fix_applicable:
             sys.stdout.write(
                 f"{noqa.NEW_LINE}{source_file}:{violation.line_number}:{violation.column_offset}:"
                 f" \033]8;;{DOCUMENTATION_URL}/rules/{violation.rule_category}/{violation.rule_name}{Style.RESET_ALL}\033\\{Fore.RED}{Style.BRIGHT}{violation.rule_code}{Style.RESET_ALL}\033]8;;\033\\:"  # noqa: E501
@@ -373,11 +373,6 @@ class Linter:
         -------
         LintResult
             Lint result.
-
-        Raises:
-        ------
-        ParseError
-            If there is an error parsing source code.
         """
         fixed_statements: list[str] = []
 
@@ -387,6 +382,7 @@ class Linter:
         )
 
         violations: set[Violation] = set()
+        _errors: set[errors.Error] = set()
 
         BaseChecker.inline_ignores = inline_ignores
         BaseChecker.source_code = source_code
@@ -398,8 +394,7 @@ class Linter:
             source_code=source_code,
         ):
             try:
-                original_tree: ast.Node = parser.parse_sql(statement.text)
-                copied_tree: ast.Node = copy.deepcopy(original_tree)
+                parse_tree: ast.Node = parser.parse_sql(statement.text)
 
                 comments = noqa.extract_comments(
                     source_file=source_file,
@@ -407,8 +402,19 @@ class Linter:
                 )
 
             except parser.ParseError as error:
-                msg = "Error parsing source code: "
-                raise errors.ParseError(f"{source_file}: " + msg + str(error)) from error
+                _errors.add(
+                    errors.Error(
+                        source_file=str(source_file),
+                        source_code=source_code,
+                        statement_start_location=statement.start_location + 1,
+                        statement_end_location=statement.end_location,
+                        statement=statement.text,
+                        message=str(error),
+                        hint=f"""Make sure the statement is valid PostgreSQL statement. If it is, please report this issue at {ISSUES_URL}\n""",  # noqa: E501
+                    ),
+                )
+                fixed_statements.append(statement.text)
+                continue
 
             BaseChecker.statement = statement.text
             BaseChecker.statement_location = statement.start_location
@@ -416,7 +422,7 @@ class Linter:
             for checker in self.checkers:
                 checker.violations = set()
 
-                checker(copied_tree)
+                checker(parse_tree)
 
                 if not self.config.lint.ignore_noqa:
                     self._skip_suppressed_violations(
@@ -427,7 +433,9 @@ class Linter:
 
                 violations.update(checker.violations)
 
-            if original_tree != copied_tree:
+            # We can run into RecursionError if we have too many nested queries
+            # We should look for a better way to check if ast has been modified
+            if parse_tree != parser.parse_sql(statement.text):
                 fixed_statement = stream.IndentedStream(
                     comments=comments,
                     semicolon_after_last_statement=False,
@@ -435,7 +443,7 @@ class Linter:
                     separate_statements=self.config.format.lines_between_statements,
                     remove_pg_catalog_from_functions=self.config.format.remove_pg_catalog_from_functions,
                     comma_at_eoln=not (self.config.format.comma_at_beginning),
-                )(copied_tree)
+                )(parse_tree)
 
                 if self.config.format.new_line_before_semicolon:
                     fixed_statement += noqa.NEW_LINE + noqa.SEMI_COLON
@@ -445,22 +453,27 @@ class Linter:
                 fixed_statements.append(fixed_statement)
 
             else:
-                fixed_statements.append(statement.text.strip())
+                fixed_statements.append(statement.text)
 
-        fixed_source_code = (
+        _fixed_source_code = (
             noqa.NEW_LINE + (noqa.NEW_LINE * self.config.format.lines_between_statements)
         ).join(
             fixed_statements,
         ) + noqa.NEW_LINE
 
-        fix = None
+        fixed_source_code = None
 
-        if parser.parse_sql(fixed_source_code) != parser.parse_sql(source_code):
-            fix = fixed_source_code
+        if _fixed_source_code.encode("utf-8") != source_code.encode("utf-8"):
+            fixed_source_code = _fixed_source_code
 
         noqa.report_unused_ignores(
             source_file=source_file,
             inline_ignores=inline_ignores,
         )
 
-        return LintResult(source_file=source_file, violations=violations, fixed_sql=fix)
+        return LintResult(
+            source_file=source_file,
+            violations=violations,
+            errors=_errors,
+            fixed_source_code=fixed_source_code,
+        )

--- a/src/pgrubic/core/noqa.py
+++ b/src/pgrubic/core/noqa.py
@@ -123,7 +123,7 @@ def _get_rules_from_inline_comment(
 
     if not rules:
         sys.stderr.write(
-            f"{Fore.YELLOW}Warning: Malformed `noqa` directive at location {location}. Expected `noqa: <rules>`{Style.RESET_ALL}\n",  # noqa: E501
+            f"{Fore.YELLOW}Warning: Malformed `noqa` directive at location {location}. Expected `noqa: <rules>`{Style.RESET_ALL}{NEW_LINE}",  # noqa: E501
         )
 
     return rules
@@ -194,7 +194,7 @@ def _extract_statement_ignores(
                 token.start,
             )
 
-            line_number = source_code[:statement_end_location].count("\n") + 1
+            line_number = source_code[:statement_end_location].count(NEW_LINE) + 1
 
             # Here, we extract last comment because we can have a comment followed
             # by another comment e.g -- new table -- noqa: US005
@@ -399,7 +399,7 @@ def report_unused_ignores(
             sys.stdout.write(
                 f"{source_file}:{ignore.line_number}:{ignore.column_offset}:"
                 f" {Fore.YELLOW}Unused noqa directive{Style.RESET_ALL}"
-                f" (unused: {Fore.RED}{Style.BRIGHT}{ignore.rule}{Style.RESET_ALL})\n",
+                f" (unused: {Fore.RED}{Style.BRIGHT}{ignore.rule}{Style.RESET_ALL}){NEW_LINE}",  # noqa: E501
             )
 
 

--- a/src/pgrubic/core/noqa.py
+++ b/src/pgrubic/core/noqa.py
@@ -46,8 +46,8 @@ def extract_statement_locations(
     statement_start_location = 0
 
     # Add semi-colon at the end if missing
-    if not source_code.rstrip(NEW_LINE).rstrip(SPACE).endswith(SEMI_COLON):
-        source_code += SEMI_COLON
+    if not source_code.strip().endswith(SEMI_COLON):
+        source_code = source_code.strip() + SEMI_COLON
 
     tokens = parser.scan(source_code)
 

--- a/src/pgrubic/core/noqa.py
+++ b/src/pgrubic/core/noqa.py
@@ -55,7 +55,7 @@ def extract_statements(
 
     inside_parenthesis = False  # Tracks if we are inside parentheses (...)
 
-    for _, token in enumerate(tokens):
+    for token in tokens:
         # Detect BEGIN
         if token.name == "BEGIN_P":
             inside_block = True

--- a/src/pgrubic/core/noqa.py
+++ b/src/pgrubic/core/noqa.py
@@ -53,6 +53,8 @@ def extract_statement_locations(
 
     inside_block = False  # Tracks if we are inside BEGIN ... END block
 
+    inside_parenthesis = False  # Tracks if we are inside parentheses (...)
+
     for _, token in enumerate(tokens):
         # Detect BEGIN
         if token.name == "BEGIN_P":

--- a/src/pgrubic/core/noqa.py
+++ b/src/pgrubic/core/noqa.py
@@ -40,11 +40,6 @@ def extract_statement_locations(
     -------
     list[Statement]
         List of statements.
-
-    Raises:
-    ------
-    MissingStatementTerminatorError
-        If semicolon is missing at the end of a statement.
     """
     locations: list[Statement] = []
 

--- a/src/pgrubic/core/noqa.py
+++ b/src/pgrubic/core/noqa.py
@@ -25,7 +25,7 @@ class Statement(typing.NamedTuple):
     text: str
 
 
-def extract_statement_locations(
+def extract_statements(
     *,
     source_code: str,
 ) -> list[Statement]:
@@ -181,7 +181,7 @@ def _extract_statement_ignores(
     list[NoQaDirective]
         List of ignores.
     """
-    locations = extract_statement_locations(
+    locations = extract_statements(
         source_code=source_code,
     )
 
@@ -296,7 +296,7 @@ def extract_format_ignores(source_code: str) -> list[int]:
     list[int]
         List of ignores.
     """
-    locations = extract_statement_locations(
+    locations = extract_statements(
         source_code=source_code,
     )
 
@@ -344,7 +344,7 @@ def extract_comments(*, source_code: str) -> list[Comment]:
     list[Comment]
         List of comments.
     """
-    locations = extract_statement_locations(
+    locations = extract_statements(
         source_code=source_code,
     )
 

--- a/src/pgrubic/core/noqa.py
+++ b/src/pgrubic/core/noqa.py
@@ -88,8 +88,9 @@ def extract_statement_locations(
                     Statement(
                         start_location=statement_start_location,
                         end_location=token.end,
-                        text=source_code[statement_start_location : token.end]
-                        + SEMI_COLON,
+                        text=(
+                            source_code[statement_start_location : token.end] + SEMI_COLON
+                        ).strip(),
                     ),
                 )
                 statement_start_location = token.end + 1

--- a/src/pgrubic/formatters/ddl/function.py
+++ b/src/pgrubic/formatters/ddl/function.py
@@ -172,7 +172,9 @@ def create_function_option(  # noqa: PLR0911
         output.write("$BODY$")
 
         if is_sql_function:
-            formatted_function_body = Formatter.run(
+            # We do not need to track errors here as the whole SQL function is already
+            # parsed by the parser
+            formatted_function_body, _ = Formatter.run(
                 source_code=function_body,
                 source_file="function_body",
                 config=_config,

--- a/src/pgrubic/formatters/ddl/function.py
+++ b/src/pgrubic/formatters/ddl/function.py
@@ -172,8 +172,8 @@ def create_function_option(  # noqa: PLR0911
         output.write("$BODY$")
 
         if is_sql_function:
-            # We do not need to track errors here as the whole SQL function is already
-            # parsed by the parser
+            # No error tracking is needed here because the SQL function body has already
+            # been parsed successfully by the parser.
             formatted_function_body, _ = Formatter.run(
                 source_code=function_body,
                 source_file="function_body",

--- a/tests/fixtures/rules/unsafe/US030.yml
+++ b/tests/fixtures/rules/unsafe/US030.yml
@@ -5,6 +5,6 @@ test_fail_mismatch_column_in_data_type_change:
   sql_fail: |
     ALTER TABLE tbl ALTER COLUMN user_id TYPE uuid USING account_id::uuid;
 
-test_pass_numeric_existing_table:
+test_pass_matching_column_in_data_type_change:
   sql_pass: |
     ALTER TABLE tbl ALTER COLUMN user_id TYPE uuid USING user_id::uuid;

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -6,6 +6,7 @@ import pathlib
 from unittest.mock import patch
 
 from pgrubic import core
+from pgrubic.core import noqa
 
 SOURCE_FILE: typing.Final[str] = "cache.sql"
 
@@ -122,7 +123,7 @@ def test_source_invalidated_in_cache_by_size(
     assert len(sources_to_be_formatted) == 0
 
     # Add a new line to source
-    source.write_text(source_code + "\n")
+    source.write_text(source_code + noqa.NEW_LINE)
 
     sources_to_be_formatted = cache.filter_sources(
         sources={source},

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -170,7 +170,7 @@ def test_cli_lint_parse_error(tmp_path: pathlib.Path) -> None:
 
     result = runner.invoke(cli, ["lint", str(file_fail)])
 
-    expected_exit_code: int = 2
+    expected_exit_code: int = 1
 
     assert result.exit_code == expected_exit_code
 
@@ -189,7 +189,7 @@ def test_cli_format_file(tmp_path: pathlib.Path) -> None:
 
     result = runner.invoke(cli, ["format", str(file_pass)])
 
-    assert result.output == "1 file(s) reformatted, 0 file(s) left unchanged\n"
+    assert result.output == "\n1 file(s) reformatted, 0 file(s) left unchanged\n"
 
     assert result.exit_code == 0
 
@@ -227,7 +227,7 @@ def test_cli_format_directory(tmp_path: pathlib.Path) -> None:
 
     result = runner.invoke(cli, ["format", str(directory)])
 
-    assert result.output == "1 file(s) reformatted, 0 file(s) left unchanged\n"
+    assert result.output == "\n1 file(s) reformatted, 0 file(s) left unchanged\n"
 
     assert result.exit_code == 0
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,6 +8,7 @@ from click import testing
 
 from tests import TEST_FILE
 from pgrubic import WORKERS_ENVIRONMENT_VARIABLE
+from pgrubic.core import noqa
 from pgrubic.__main__ import cli
 
 
@@ -97,7 +98,29 @@ def test_cli_lint_with_add_file_level_general_noqa(tmp_path: pathlib.Path) -> No
 
     result = runner.invoke(cli, ["lint", str(file_fail), "--add-file-level-general-noqa"])
 
-    assert result.output == "File-level general noqa directive added to 1 file(s)\n"
+    assert (
+        result.output
+        == f"File-level general noqa directive added to 1 file(s){noqa.NEW_LINE}"
+    )
+
+    assert result.exit_code == 0
+
+
+def test_cli_lint_no_violations(tmp_path: pathlib.Path) -> None:
+    """Test cli lint with add_file_level_general_noqa."""
+    runner = testing.CliRunner()
+
+    sql_fail: str = "SELECT a;"
+
+    directory = tmp_path / "sub"
+    directory.mkdir()
+
+    file_fail = directory / TEST_FILE
+    file_fail.write_text(sql_fail)
+
+    result = runner.invoke(cli, ["lint", str(file_fail)])
+
+    assert result.output == f"All checks passed!{noqa.NEW_LINE}"
 
     assert result.exit_code == 0
 
@@ -170,16 +193,14 @@ def test_cli_lint_parse_error(tmp_path: pathlib.Path) -> None:
 
     result = runner.invoke(cli, ["lint", str(file_fail)])
 
-    expected_exit_code: int = 1
-
-    assert result.exit_code == expected_exit_code
+    assert result.exit_code == 1
 
 
 def test_cli_format_file(tmp_path: pathlib.Path) -> None:
     """Test cli format file."""
     runner = testing.CliRunner()
 
-    sql_pass: str = "SELECT a = NULL;\n"
+    sql_pass: str = f"SELECT a = NULL;{noqa.NEW_LINE}"
 
     directory = tmp_path / "sub"
     directory.mkdir()
@@ -189,7 +210,10 @@ def test_cli_format_file(tmp_path: pathlib.Path) -> None:
 
     result = runner.invoke(cli, ["format", str(file_pass)])
 
-    assert result.output == "\n1 file(s) reformatted, 0 file(s) left unchanged\n"
+    assert (
+        result.output
+        == f"{noqa.NEW_LINE}1 file(s) reformatted, 0 file(s) left unchanged{noqa.NEW_LINE}"  # noqa: E501
+    )
 
     assert result.exit_code == 0
 
@@ -198,7 +222,7 @@ def test_cli_format_file_verbose(tmp_path: pathlib.Path) -> None:
     """Test cli format file."""
     runner = testing.CliRunner()
 
-    sql_pass: str = "SELECT a = NULL;\n"
+    sql_pass: str = f"SELECT a = NULL;{noqa.NEW_LINE}"
 
     directory = tmp_path / "sub"
     directory.mkdir()
@@ -217,7 +241,7 @@ def test_cli_format_directory(tmp_path: pathlib.Path) -> None:
     """Test cli format directory."""
     runner = testing.CliRunner()
 
-    sql_pass: str = "SELECT a = NULL;\n"
+    sql_pass: str = f"SELECT a = NULL;{noqa.NEW_LINE}"
 
     directory = tmp_path / "sub"
     directory.mkdir()
@@ -227,7 +251,10 @@ def test_cli_format_directory(tmp_path: pathlib.Path) -> None:
 
     result = runner.invoke(cli, ["format", str(directory)])
 
-    assert result.output == "\n1 file(s) reformatted, 0 file(s) left unchanged\n"
+    assert (
+        result.output
+        == f"{noqa.NEW_LINE}1 file(s) reformatted, 0 file(s) left unchanged{noqa.NEW_LINE}"  # noqa: E501
+    )
 
     assert result.exit_code == 0
 
@@ -250,7 +277,10 @@ def test_cli_format_current_directory(
 
     result = runner.invoke(cli, ["format"])
 
-    assert result.output == "1 file(s) reformatted, 0 file(s) left unchanged\n"
+    assert (
+        result.output
+        == f"{noqa.NEW_LINE}1 file(s) reformatted, 0 file(s) left unchanged{noqa.NEW_LINE}"  # noqa: E501
+    )
 
     assert result.exit_code == 0
 
@@ -270,6 +300,25 @@ def test_cli_format_check(tmp_path: pathlib.Path) -> None:
     result = runner.invoke(cli, ["format", str(file_fail), "--check"])
 
     assert result.output == ""
+
+    assert result.exit_code == 1
+
+
+def test_cli_format_check_parse_error(tmp_path: pathlib.Path) -> None:
+    """Test cli format check parse error."""
+    runner = testing.CliRunner()
+
+    sql_fail: str = "SELECT a ="
+
+    directory = tmp_path / "sub"
+    directory.mkdir()
+
+    file_fail = directory / TEST_FILE
+    file_fail.write_text(sql_fail)
+
+    result = runner.invoke(cli, ["format", str(file_fail), "--check"])
+
+    assert f"1 error(s) found{noqa.NEW_LINE}" in result.output
 
     assert result.exit_code == 1
 
@@ -305,21 +354,30 @@ def test_cli_format_no_cache(tmp_path: pathlib.Path) -> None:
 
     result = runner.invoke(cli, ["format", str(file_fail)])
 
-    assert result.output == "1 file(s) reformatted, 0 file(s) left unchanged\n"
+    assert (
+        result.output
+        == f"{noqa.NEW_LINE}1 file(s) reformatted, 0 file(s) left unchanged{noqa.NEW_LINE}"  # noqa: E501
+    )
 
     assert result.exit_code == 0
 
     # with cache read
     result = runner.invoke(cli, ["format", str(file_fail)])
 
-    assert result.output == "0 file(s) reformatted, 1 file(s) left unchanged\n"
+    assert (
+        result.output
+        == f"{noqa.NEW_LINE}0 file(s) reformatted, 1 file(s) left unchanged{noqa.NEW_LINE}"  # noqa: E501
+    )
 
     assert result.exit_code == 0
 
     # without cache
     result = runner.invoke(cli, ["format", str(file_fail), "--no-cache"])
 
-    assert result.output == "1 file(s) reformatted, 0 file(s) left unchanged\n"
+    assert (
+        result.output
+        == f"{noqa.NEW_LINE}1 file(s) reformatted, 0 file(s) left unchanged{noqa.NEW_LINE}"  # noqa: E501
+    )
 
     assert result.exit_code == 0
 
@@ -338,28 +396,7 @@ def test_cli_format_parse_error(tmp_path: pathlib.Path) -> None:
 
     result = runner.invoke(cli, ["format", str(file_fail)])
 
-    expected_exit_code: int = 2
-
-    assert result.exit_code == expected_exit_code
-
-
-def test_cli_format_missing_terminator_error(tmp_path: pathlib.Path) -> None:
-    """Test cli format missing terminator error."""
-    runner = testing.CliRunner()
-
-    sql: str = "SELECT * FROM tbl"
-
-    directory = tmp_path / "sub"
-    directory.mkdir()
-
-    file_fail = directory / TEST_FILE
-    file_fail.write_text(sql)
-
-    result = runner.invoke(cli, ["format", str(file_fail)])
-
-    expected_exit_code: int = 2
-
-    assert result.exit_code == expected_exit_code
+    assert result.exit_code == 1
 
 
 def test_max_workers_from_environment_variable(tmp_path: pathlib.Path) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -308,7 +308,7 @@ def test_cli_format_check_parse_error(tmp_path: pathlib.Path) -> None:
     """Test cli format check parse error."""
     runner = testing.CliRunner()
 
-    sql_fail: str = "SELECT a ="
+    sql_fail: str = "SELECT a =;"
 
     directory = tmp_path / "sub"
     directory.mkdir()

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -7,7 +7,7 @@ from unittest.mock import patch
 import git
 
 from pgrubic import core
-from pgrubic.core import config
+from pgrubic.core import noqa, config
 
 
 def test_filter_linting_sources(tmp_path: pathlib.Path) -> None:
@@ -135,7 +135,7 @@ def test_respect_gitignore_filter_sources(tmp_path: pathlib.Path) -> None:
 
     # Create a .gitignore file in the repository
     gitignore_file = tmp_path / ".gitignore"
-    gitignore_file.write_text("ignored_file.sql\n")
+    gitignore_file.write_text(f"ignored_file.sql{noqa.NEW_LINE}")
 
     directory = tmp_path / "sub"
     directory.mkdir()
@@ -196,7 +196,7 @@ def test_respect_gitignore_false_filter_sources(tmp_path: pathlib.Path) -> None:
 
     # Create a .gitignore file in the repository
     gitignore_file = tmp_path / ".gitignore"
-    gitignore_file.write_text("ignored_file.sql\n")
+    gitignore_file.write_text("ignored_file.sql{noqa.NEW_LINE}")
 
     directory = tmp_path / "sub"
     directory.mkdir()

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -196,7 +196,7 @@ def test_respect_gitignore_false_filter_sources(tmp_path: pathlib.Path) -> None:
 
     # Create a .gitignore file in the repository
     gitignore_file = tmp_path / ".gitignore"
-    gitignore_file.write_text("ignored_file.sql{noqa.NEW_LINE}")
+    gitignore_file.write_text(f"ignored_file.sql{noqa.NEW_LINE}")
 
     directory = tmp_path / "sub"
     directory.mkdir()

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -8,7 +8,7 @@ from pglast import parser
 
 from tests import TEST_FILE, conftest
 from pgrubic import core
-from pgrubic.core import errors
+from pgrubic.core import noqa
 
 
 @pytest.mark.parametrize(
@@ -51,16 +51,16 @@ def test_formatters(
 
 
 def test_format_parse_error(formatter: core.Formatter) -> None:
-    """Test format."""
+    """Test parse error."""
     source_code = "SELECT * FROM;"
-    with pytest.raises(errors.ParseError):
-        formatter.format(source_file=TEST_FILE, source_code=source_code)
+    formatting_result = formatter.format(source_file=TEST_FILE, source_code=source_code)
+    assert len(formatting_result.errors) == 1
 
 
 def test_new_line_before_semicolon(formatter: core.Formatter) -> None:
     """Test new line before semicolon."""
     source_code = "select 1;"
-    expected_output: str = "SELECT 1\n;\n"
+    expected_output: str = f"SELECT 1{noqa.NEW_LINE};{noqa.NEW_LINE}"
 
     formatter.config.format.new_line_before_semicolon = True
 

--- a/tests/test_linter.py
+++ b/tests/test_linter.py
@@ -1,9 +1,6 @@
 """Test linter."""
 
-import pytest
-
 from pgrubic import core
-from pgrubic.core import errors
 
 SOURCE_FILE = "linter.sql"
 
@@ -52,7 +49,7 @@ def test_linter_suppressed_certain_violations(
     assert len(linting_result.violations) == 1
 
 
-def test_linter_violations_fixed_sql(
+def test_linter_violations_fixed_source_code(
     linter: core.Linter,
 ) -> None:
     """Test linter fixed sql."""
@@ -62,36 +59,22 @@ def test_linter_violations_fixed_sql(
         source_code="SELECT a = NULL;",
     )
 
-    assert linting_result.fixed_sql == "SELECT a IS NULL;\n"
+    assert linting_result.fixed_source_code == "SELECT a IS NULL;\n"
 
 
-def test_linter_suppressed_violations_fixed_sql(
+def test_linter_suppressed_violations_fixed_source_code(
     linter: core.Linter,
 ) -> None:
     """Test linter suppressed violations fixed sql."""
     linter.config.lint.fix = True
     linting_result = linter.run(
         source_file=SOURCE_FILE,
-        source_code="""
-        -- noqa: GN024
-        SELECT a = NULL;
-        """,
+        source_code="""-- noqa: GN024
+SELECT a = NULL;
+""",
     )
 
-    assert not linting_result.fixed_sql
-
-
-def test_parse_error(linter: core.Linter) -> None:
-    """Test parse error."""
-    source_code: str = """
-    CREATE TABLE tbl (activated);
-    """
-
-    with pytest.raises(errors.ParseError):
-        linter.run(
-            source_file=SOURCE_FILE,
-            source_code=source_code,
-        )
+    assert not linting_result.fixed_source_code
 
 
 def test_new_line_before_semicolon(
@@ -105,7 +88,7 @@ def test_new_line_before_semicolon(
         source_code="SELECT a = NULL;",
     )
 
-    assert linting_result.fixed_sql == "SELECT a IS NULL\n;\n"
+    assert linting_result.fixed_source_code == "SELECT a IS NULL\n;\n"
 
 
 def test_fix_enabledment(
@@ -119,4 +102,4 @@ def test_fix_enabledment(
         source_code="SELECT a = NULL;",
     )
 
-    assert linting_result.fixed_sql == "SELECT a IS NULL\n;\n"
+    assert linting_result.fixed_source_code == "SELECT a IS NULL\n;\n"

--- a/tests/test_linter.py
+++ b/tests/test_linter.py
@@ -80,9 +80,7 @@ SELECT a = NULL;
 
 def test_lint_parse_error(linter: core.Linter) -> None:
     """Test parse error."""
-    source_code: str = """
-    CREATE TABLE tbl (activated);
-    """
+    source_code: str = "CREATE TABLE tbl (activated);"
 
     linting_result = linter.run(
         source_file=SOURCE_FILE,

--- a/tests/test_linter.py
+++ b/tests/test_linter.py
@@ -1,6 +1,7 @@
 """Test linter."""
 
 from pgrubic import core
+from pgrubic.core import noqa
 
 SOURCE_FILE = "linter.sql"
 
@@ -59,7 +60,7 @@ def test_linter_violations_fixed_source_code(
         source_code="SELECT a = NULL;",
     )
 
-    assert linting_result.fixed_source_code == "SELECT a IS NULL;\n"
+    assert linting_result.fixed_source_code == f"SELECT a IS NULL;{noqa.NEW_LINE}"
 
 
 def test_linter_suppressed_violations_fixed_source_code(
@@ -77,6 +78,20 @@ SELECT a = NULL;
     assert not linting_result.fixed_source_code
 
 
+def test_lint_parse_error(linter: core.Linter) -> None:
+    """Test parse error."""
+    source_code: str = """
+    CREATE TABLE tbl (activated);
+    """
+
+    linting_result = linter.run(
+        source_file=SOURCE_FILE,
+        source_code=source_code,
+    )
+
+    assert len(linting_result.errors) == 1
+
+
 def test_new_line_before_semicolon(
     linter: core.Linter,
 ) -> None:
@@ -88,7 +103,12 @@ def test_new_line_before_semicolon(
         source_code="SELECT a = NULL;",
     )
 
-    assert linting_result.fixed_source_code == "SELECT a IS NULL\n;\n"
+    linter.config.format.new_line_before_semicolon = False
+
+    assert (
+        linting_result.fixed_source_code
+        == f"SELECT a IS NULL{noqa.NEW_LINE};{noqa.NEW_LINE}"
+    )
 
 
 def test_fix_enabledment(
@@ -102,4 +122,4 @@ def test_fix_enabledment(
         source_code="SELECT a = NULL;",
     )
 
-    assert linting_result.fixed_source_code == "SELECT a IS NULL\n;\n"
+    assert linting_result.fixed_source_code == f"SELECT a IS NULL;{noqa.NEW_LINE}"

--- a/tests/test_noqa.py
+++ b/tests/test_noqa.py
@@ -3,11 +3,10 @@
 import typing
 import pathlib
 
-import pytest
 from colorama import Fore, Style
 
 from tests import TEST_FILE
-from pgrubic.core import noqa, errors
+from pgrubic.core import noqa
 
 
 def test_extract_star_ignore_from_inline_comments() -> None:
@@ -70,7 +69,7 @@ def test_wrongly_formed_inline_ignores_from_inline_comments(capfd: typing.Any) -
 
     assert (
         err
-        == f"{Fore.YELLOW}Warning: Malformed `noqa` directive at location 5. Expected `noqa: <rules>`{Style.RESET_ALL}\n"  # noqa: E501
+        == f"{Fore.YELLOW}Warning: Malformed `noqa` directive at location 5. Expected `noqa: <rules>`{Style.RESET_ALL}{noqa.NEW_LINE}"  # noqa: E501
     )
 
 
@@ -92,19 +91,8 @@ def test_report_specific_unused_ignores(
     out, _ = capfd.readouterr()
     assert (
         out
-        == f"{TEST_FILE}:3:52: {Fore.YELLOW}Unused noqa directive{Style.RESET_ALL} (unused: {Fore.RED}{Style.BRIGHT}NM016{Style.RESET_ALL})\n"  # noqa: E501
+        == f"{TEST_FILE}:3:52: {Fore.YELLOW}Unused noqa directive{Style.RESET_ALL} (unused: {Fore.RED}{Style.BRIGHT}NM016{Style.RESET_ALL}){noqa.NEW_LINE}"  # noqa: E501
     )
-
-
-def test_missing_statement_terminator() -> None:
-    """Test missing statement terminator."""
-    source_code: str = "SELECT * FROM tab"
-
-    with pytest.raises(errors.MissingStatementTerminatorError):
-        noqa.extract_comments(
-            source_file=TEST_FILE,
-            source_code=source_code,
-        )
 
 
 def test_report_general_unused_ignores(
@@ -125,7 +113,7 @@ def test_report_general_unused_ignores(
     out, _ = capfd.readouterr()
     assert (
         out
-        == f"{TEST_FILE}:3:45: {Fore.YELLOW}Unused noqa directive{Style.RESET_ALL} (unused: {Fore.RED}{Style.BRIGHT}{noqa.A_STAR}{Style.RESET_ALL})\n"  # noqa: E501
+        == f"{TEST_FILE}:3:45: {Fore.YELLOW}Unused noqa directive{Style.RESET_ALL} (unused: {Fore.RED}{Style.BRIGHT}{noqa.A_STAR}{Style.RESET_ALL}){noqa.NEW_LINE}"  # noqa: E501
     )
 
 
@@ -138,7 +126,7 @@ def test_add_file_level_general_ignore(tmp_path: pathlib.Path) -> None:
     source_file1.write_text("SELECT * FROM tab")
 
     source_file2 = directory / "source_file2.sql"
-    source_file2.write_text("-- pgrubic: noqa\n SELECT * FROM tab")
+    source_file2.write_text(f"-- pgrubic: noqa{noqa.NEW_LINE} SELECT * FROM tab")  # noqa: S608
 
     modified_sources = noqa.add_file_level_general_ignore(
         sources={source_file1, source_file2},

--- a/tests/test_noqa.py
+++ b/tests/test_noqa.py
@@ -142,7 +142,7 @@ def test_statement_without_semi_colon() -> None:
 
     """
 
-    extracted_statements = noqa.extract_statement_locations(source_code=source_code)
+    extracted_statements = noqa.extract_statements(source_code=source_code)
 
     assert extracted_statements[0].text == "CREATE TABLE tbl (activated date);"
 
@@ -159,6 +159,6 @@ CREATE TABLE tbl (
     activated date
 );"""
 
-    extracted_statements = noqa.extract_statement_locations(source_code=source_code)
+    extracted_statements = noqa.extract_statements(source_code=source_code)
 
     assert extracted_statements[0].text == expected_statement

--- a/tests/test_noqa.py
+++ b/tests/test_noqa.py
@@ -133,3 +133,32 @@ def test_add_file_level_general_ignore(tmp_path: pathlib.Path) -> None:
     )
 
     assert modified_sources == 1
+
+
+def test_statement_without_semi_colon() -> None:
+    """Test statements without semicolon."""
+    source_code: str = """
+    CREATE TABLE tbl (activated date)
+
+    """
+
+    extracted_statements = noqa.extract_statement_locations(source_code=source_code)
+
+    assert extracted_statements[0].text == "CREATE TABLE tbl (activated date);"
+
+
+def test_indented_statement_without_semi_colon() -> None:
+    """Test statements without semicolon."""
+    source_code: str = """
+CREATE TABLE tbl (
+    activated date
+)
+
+    """
+    expected_statement = """CREATE TABLE tbl (
+    activated date
+);"""
+
+    extracted_statements = noqa.extract_statement_locations(source_code=source_code)
+
+    assert extracted_statements[0].text == expected_statement

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -62,11 +62,11 @@ def test_rules(
         ), f"Test failed: No violations found for rule: `{rule}` in `{test_id}`"
 
         if parsed_test_case.sql_fix:
-            assert linting_result.fixed_sql == parsed_test_case.sql_fix
+            assert linting_result.fixed_source_code == parsed_test_case.sql_fix
 
-            # Check that the fixed sql is valid
+            # Check that the fixed source_code is valid
             try:
-                parser.parse_sql(linting_result.fixed_sql)
+                parser.parse_sql(linting_result.fixed_source_code)
             except parser.ParseError as error:
                 msg = f"Formatted code is not a valid syntax: {error!s}"
                 raise ValueError(msg) from error


### PR DESCRIPTION
**pgrubic** currently crashes when there is an error due to the source code we are linting or formatting. Such crashes stop processing immediately even if there are subsequent good files, making the tool not developer-friendly.

The new implementation builds a list of errors and return it to the caller, this ensures we exit graceful. This is exactly what we do currently with violations where we return all the violations instead of stopping on the first violation. This also makes the APIs more useful.

Along the new implementation, we are also changing the way we check if there were modifications to the AST by fixes. Now, we track fixes by the checkers per statement through the checker Metaclass which is responsible for application of fixes. Now, we do not need to reparse the statement to compare it with the original AST.
