### PR TITLE
feat: add support for skipping formatting of a whole file, simplify statements extraction, improve column offset for noqa directives

### DIFF
--- a/docs/docs/formatter.md
+++ b/docs/docs/formatter.md
@@ -62,4 +62,4 @@ For the full list of all supported settings, see [**settings**](settings.md#form
 Similar to several other formatters, the pgrubic formatter provides various ways to skip formatting a statement/file.
 
 - To skip formatting a statement, add `-- fmt: skip` directive to the top of the statement
-- To skip formatting a file completely, add the file name to the [**format.exclude**](settings.md/#exclude_2) setting
+- To skip formatting a file, you can use either use `-- pgrubic: fmt: skip` directive at the top of the file or add the file name to the [**format.exclude**](settings.md/#exclude_2) setting

--- a/src/pgrubic/__main__.py
+++ b/src/pgrubic/__main__.py
@@ -124,7 +124,7 @@ def lint(  # noqa: C901, PLR0912, PLR0913
     )
 
     if add_file_level_general_noqa:
-        sources_modified = noqa.add_file_level_general_ignore(included_sources)
+        sources_modified = noqa.add_file_level_general_lint_ignore(included_sources)
         sys.stdout.write(
             f"File-level general noqa directive added to {sources_modified} file(s){noqa.NEW_LINE}",  # noqa: E501
         )

--- a/src/pgrubic/core/formatter.py
+++ b/src/pgrubic/core/formatter.py
@@ -55,19 +55,22 @@ class Formatter:
 
         formatted_statements: list[str] = []
 
-        format_ignores = noqa.extract_format_ignores(
+        statements = noqa.extract_statements(
             source_code=source_code,
         )
 
-        for statement in noqa.extract_statements(
+        format_ignores = noqa.extract_statement_format_ignores(
             source_code=source_code,
-        ):
+            statements=statements,
+        )
+
+        for statement in statements:
             if statement.start_location in format_ignores:
                 formatted_statements.append(statement.text)
                 continue
 
             comments = noqa.extract_comments(
-                source_code=statement.text,
+                statement=statement,
             )
 
             try:

--- a/src/pgrubic/core/formatter.py
+++ b/src/pgrubic/core/formatter.py
@@ -59,13 +59,8 @@ class Formatter:
             source_code=source_code,
         )
 
-        format_ignores = noqa.extract_statement_format_ignores(
-            source_code=source_code,
-            statements=statements,
-        )
-
         for statement in statements:
-            if statement.start_location in format_ignores:
+            if noqa.check_statement_format_skip(statement=statement):
                 formatted_statements.append(statement.text)
                 continue
 

--- a/src/pgrubic/core/linter.py
+++ b/src/pgrubic/core/linter.py
@@ -109,7 +109,8 @@ class CheckerMeta(type):
             checker.line_number = (
                 checker.source_code[: checker.node_location].count(noqa.NEW_LINE) + 1
             )
-            checker.column_offset = checker.node_location - line_start + 1
+            # We account for a single space thus +1
+            checker.column_offset = (checker.node_location - line_start) + 1
 
             # If a node has no location, we return the whole statement instead
             if hasattr(node, "location") and isinstance(node.location, int):

--- a/src/pgrubic/core/linter.py
+++ b/src/pgrubic/core/linter.py
@@ -163,7 +163,7 @@ class BaseChecker(visitors.Visitor, metaclass=CheckerMeta):  # type: ignore[misc
 
     # Attributes shared among all subclasses
     config: config.Config
-    inline_ignores: list[noqa.NoQaDirective]
+    lint_ignores: list[noqa.NoQaDirective]
     source_file: str
     source_code: str
 
@@ -222,7 +222,7 @@ class BaseChecker(visitors.Visitor, metaclass=CheckerMeta):  # type: ignore[misc
             return False
 
         # if the violation has been suppressed by noqa, there is no need to try to fix it
-        for inline_ignore in self.inline_ignores:
+        for inline_ignore in self.lint_ignores:
             if (
                 (
                     self.statement_location == inline_ignore.location
@@ -260,7 +260,7 @@ class Linter:
         *,
         source_file: str,
         checker: BaseChecker,
-        inline_ignores: list[noqa.NoQaDirective],
+        lint_ignores: list[noqa.NoQaDirective],
     ) -> None:
         """Skip suppressed violations.
 
@@ -268,16 +268,18 @@ class Linter:
         ----------
         source_file: str
             Path to the source file.
+
         checker: BaseChecker
             Lint rule checker.
-        inline_ignores: list[NoQaDirective]
-            Inline noqa directives.
+
+        lint_ignores: list[NoQaDirective]
+            List of noqa directives.
 
         Returns:
         -------
         None
         """
-        for inline_ignore in inline_ignores:
+        for inline_ignore in lint_ignores:
             suppressed_violations: set[Violation] = {
                 violation
                 for violation in checker.violations
@@ -383,27 +385,31 @@ class Linter:
         """
         fixed_statements: list[str] = []
 
-        inline_ignores: list[noqa.NoQaDirective] = noqa.extract_ignores(
-            source_file=source_file,
-            source_code=source_code,
-        )
-
         violations: set[Violation] = set()
         _errors: set[errors.Error] = set()
 
-        BaseChecker.inline_ignores = inline_ignores
         BaseChecker.source_code = source_code
         BaseChecker.source_file = source_file
         BaseChecker.config = self.config
 
-        for statement in noqa.extract_statements(
+        statements = noqa.extract_statements(
             source_code=source_code,
-        ):
+        )
+
+        lint_ignores: list[noqa.NoQaDirective] = noqa.extract_lint_ignores(
+            source_file=source_file,
+            source_code=source_code,
+            statements=statements,
+        )
+
+        BaseChecker.lint_ignores = lint_ignores
+
+        for statement in statements:
             try:
                 parse_tree: ast.Node = parser.parse_sql(statement.text)
 
                 comments = noqa.extract_comments(
-                    source_code=statement.text,
+                    statement=statement,
                 )
 
             except parser.ParseError as error:
@@ -435,7 +441,7 @@ class Linter:
                     self._skip_suppressed_violations(
                         source_file=source_file,
                         checker=checker,
-                        inline_ignores=inline_ignores,
+                        lint_ignores=lint_ignores,
                     )
 
                 violations.update(checker.violations)
@@ -487,9 +493,9 @@ class Linter:
         ):
             fixed_source_code = _fixed_source_code
 
-        noqa.report_unused_ignores(
+        noqa.report_unused_lint_ignores(
             source_file=source_file,
-            inline_ignores=inline_ignores,
+            lint_ignores=lint_ignores,
         )
 
         return LintResult(

--- a/src/pgrubic/core/linter.py
+++ b/src/pgrubic/core/linter.py
@@ -396,15 +396,15 @@ class Linter:
             source_code=source_code,
         )
 
-        lint_ignores: list[noqa.NoQaDirective] = noqa.extract_lint_ignores(
-            source_file=source_file,
-            source_code=source_code,
-            statements=statements,
-        )
-
-        BaseChecker.lint_ignores = lint_ignores
-
         for statement in statements:
+            lint_ignores: list[noqa.NoQaDirective] = noqa.extract_lint_ignores(
+                source_file=source_file,
+                source_code=source_code,
+                statement=statement,
+            )
+
+            BaseChecker.lint_ignores = lint_ignores
+
             try:
                 parse_tree: ast.Node = parser.parse_sql(statement.text)
 

--- a/src/pgrubic/core/linter.py
+++ b/src/pgrubic/core/linter.py
@@ -401,6 +401,8 @@ class Linter:
             source_code=source_code,
         )
 
+        lint_ignores = file_lint_ignores
+
         for statement in statements:
             statement_lint_ignores: list[noqa.NoQaDirective] = (
                 noqa.extract_statement_lint_ignores(
@@ -409,7 +411,7 @@ class Linter:
                 )
             )
 
-            lint_ignores = file_lint_ignores + statement_lint_ignores
+            lint_ignores.extend(statement_lint_ignores)
 
             BaseChecker.lint_ignores = lint_ignores
 

--- a/src/pgrubic/core/linter.py
+++ b/src/pgrubic/core/linter.py
@@ -396,12 +396,20 @@ class Linter:
             source_code=source_code,
         )
 
+        file_lint_ignores = noqa.extract_file_lint_ignores(
+            source_file=source_file,
+            source_code=source_code,
+        )
+
         for statement in statements:
-            lint_ignores: list[noqa.NoQaDirective] = noqa.extract_lint_ignores(
-                source_file=source_file,
-                source_code=source_code,
-                statement=statement,
+            statement_lint_ignores: list[noqa.NoQaDirective] = (
+                noqa.extract_statement_lint_ignores(
+                    statement=statement,
+                    source_code=source_code,
+                )
             )
+
+            lint_ignores = file_lint_ignores + statement_lint_ignores
 
             BaseChecker.lint_ignores = lint_ignores
 

--- a/src/pgrubic/core/noqa.py
+++ b/src/pgrubic/core/noqa.py
@@ -271,16 +271,12 @@ def extract_file_lint_ignores(
 
 def check_file_format_skip(
     *,
-    # source_file: str,
     source_code: str,
 ) -> bool:
     """Check if formatting should be skipped for source code.
 
     Parameters:
     ----------
-    # source_file: str
-    #     The source file.
-
     source_code: str
         Source code to check file format skip for.
 
@@ -300,8 +296,8 @@ def check_file_format_skip(
             )
 
             return bool(
-                comment.startswith(FORMAT_IGNORE_DIRECTIVE)
-                and comment.removeprefix(FORMAT_IGNORE_DIRECTIVE)
+                comment.startswith(f"{PACKAGE_NAME}: {FORMAT_IGNORE_DIRECTIVE}")
+                and comment.removeprefix(f"{PACKAGE_NAME}: {FORMAT_IGNORE_DIRECTIVE}")
                 .removeprefix(":")
                 .strip()
                 == "skip",

--- a/src/pgrubic/core/noqa.py
+++ b/src/pgrubic/core/noqa.py
@@ -85,6 +85,8 @@ def extract_statements(
         # Check if we have reached a semi-colon or the end of the source code
         if token.name == ASCII_SEMI_COLON or token is tokens[-1]:
             if not (inside_block or inside_parenthesis):
+                # In order to include the last character, we need to increase the end
+                # location by 1
                 actual_end_location = token.end + 1
                 locations.append(
                     Statement(
@@ -179,7 +181,7 @@ def extract_statement_lint_ignores(
     for token in typing.cast(list[Token], parser.scan(statement.text)):
         if token.name == SQL_COMMENT:
             # In order to include the last character, we need to increase the end
-            # location by one
+            # location by 1
             actual_end_location = token.end + 1
 
             line_number = source_code[:actual_end_location].count(NEW_LINE) + 1

--- a/src/pgrubic/core/noqa.py
+++ b/src/pgrubic/core/noqa.py
@@ -82,11 +82,9 @@ def extract_statements(
         if token.name == ASCII_CLOSE_PARENTHESIS:
             inside_parenthesis = False  # Parenthesis ends
 
+        # Check if we have reached a semi-colon or the end of the source code
         if token.name == ASCII_SEMI_COLON or token is tokens[-1]:
             if not (inside_block or inside_parenthesis):
-                # For ASCII_SEMI_COLON, both start and end locations are the same and
-                # in order to still have it in the statement, we need to increase the end
-                # location by one
                 actual_end_location = token.end + 1
                 locations.append(
                     Statement(

--- a/tests/fixtures/formatters/skip_format.yml
+++ b/tests/fixtures/formatters/skip_format.yml
@@ -1,7 +1,7 @@
 ---
 formatter: SELECT
 
-skip_format_right_marker:
+skip_format_correct_marker:
   sql: |
     -- fmt: skip
     select 1;
@@ -23,4 +23,39 @@ skip_format_not_working_due_to_noisy_space_in_marker:
     select 1;
   expected: |
     -- fmt : skip
+    SELECT 1;
+
+skip_file_format_correct_marker:
+  sql: |
+    -- pgrubic: fmt: skip
+    select 1;
+    select 1;
+  expected: |
+    -- pgrubic: fmt: skip
+    select 1;
+    select 1;
+  config:
+    format:
+      lines_between_statements: 1
+
+skip_file_format_not_working_due_to_wrong_marker:
+  sql: |
+    -- pgrubic: fmt:
+    select 1;
+    select 1;
+  expected: |
+    -- pgrubic: fmt:
+    SELECT 1;
+
+    SELECT 1;
+
+skip_file_format_not_working_due_to_noisy_space_in_marker:
+  sql: |
+    -- pgrubic: fmt : skip
+    select 1;
+    select 1;
+  expected: |
+    -- pgrubic: fmt : skip
+    SELECT 1;
+
     SELECT 1;

--- a/tests/test_linter.py
+++ b/tests/test_linter.py
@@ -109,10 +109,10 @@ def test_new_line_before_semicolon(
     )
 
 
-def test_fix_enabledment(
+def test_fix_enablement(
     linter: core.Linter,
 ) -> None:
-    """Test fix enabledment."""
+    """Test fix enablement."""
     linter.config.lint.fix = True
     linter.config.lint.fixable = ["GN024"]
     linting_result = linter.run(

--- a/tests/test_noqa.py
+++ b/tests/test_noqa.py
@@ -110,7 +110,7 @@ def test_report_specific_unused_ignores(
     out, _ = capfd.readouterr()
     assert (
         out
-        == f"{TEST_FILE}:1:53: {Fore.YELLOW}Unused noqa directive{Style.RESET_ALL} (unused: {Fore.RED}{Style.BRIGHT}NM016{Style.RESET_ALL}){noqa.NEW_LINE}"  # noqa: E501
+        == f"{TEST_FILE}:1:1: {Fore.YELLOW}Unused noqa directive{Style.RESET_ALL} (unused: {Fore.RED}{Style.BRIGHT}NM016{Style.RESET_ALL}){noqa.NEW_LINE}"  # noqa: E501
     )
 
 
@@ -132,7 +132,7 @@ def test_report_star_unused_ignores(
     out, _ = capfd.readouterr()
     assert (
         out
-        == f"{TEST_FILE}:2:46: {Fore.YELLOW}Unused noqa directive{Style.RESET_ALL} (unused: {Fore.RED}{Style.BRIGHT}{noqa.A_STAR}{Style.RESET_ALL}){noqa.NEW_LINE}"  # noqa: E501
+        == f"{TEST_FILE}:2:5: {Fore.YELLOW}Unused noqa directive{Style.RESET_ALL} (unused: {Fore.RED}{Style.BRIGHT}{noqa.A_STAR}{Style.RESET_ALL}){noqa.NEW_LINE}"  # noqa: E501
     )
 
 

--- a/tests/test_noqa.py
+++ b/tests/test_noqa.py
@@ -10,15 +10,14 @@ from pgrubic import PACKAGE_NAME
 from pgrubic.core import noqa
 
 
-def test_extract_star_ignore_from_inline_comments() -> None:
-    """Test extract star ignore from inline comments."""
+def test_extract_star_statement_lint_ignore() -> None:
+    """Test extract star statement lint ignore."""
     source_code: str = """
     -- noqa
     CREATE TABLE tbl (activated date);
     """
 
-    lint_ignores: list[noqa.NoQaDirective] = noqa.extract_lint_ignores(
-        source_file=TEST_FILE,
+    lint_ignores: list[noqa.NoQaDirective] = noqa.extract_statement_lint_ignores(
         source_code=source_code,
         statement=noqa.extract_statements(source_code=source_code)[0],
     )
@@ -26,49 +25,62 @@ def test_extract_star_ignore_from_inline_comments() -> None:
     assert lint_ignores[0].rule == noqa.A_STAR
 
 
-def test_extract_ignores() -> None:
-    """Test extract ignores from inline comments."""
+def test_extract_file_lint_ignores() -> None:
+    """Test extract file lint ignores."""
     source_code: str = f"""-- {PACKAGE_NAME}: noqa: NM016, GN001
     CREATE TABLE tbl (activated date);
     """
 
-    lint_ignores: list[noqa.NoQaDirective] = noqa.extract_lint_ignores(
-        source_file=str(TEST_FILE),
+    lint_ignores: list[noqa.NoQaDirective] = noqa.extract_file_lint_ignores(
+        source_file=TEST_FILE,
         source_code=source_code,
-        statement=noqa.extract_statements(source_code=source_code)[0],
     )
 
     assert lint_ignores[0].rule == "NM016"
     assert lint_ignores[1].rule == "GN001"
 
 
-def test_extract_ignores_length() -> None:
-    """Test extract ignore from inline comments length."""
+def test_extract_file_lint_ignores_length() -> None:
+    """Test extract file lint ignores length."""
+    source_code: str = f"""-- {PACKAGE_NAME}: noqa: NM016, GN001
+    CREATE TABLE tbl (activated date);
+    """
+
+    lint_ignores: list[noqa.NoQaDirective] = noqa.extract_file_lint_ignores(
+        source_file=TEST_FILE,
+        source_code=source_code,
+    )
+
+    expected_lint_ignores_length: int = 2
+
+    assert len(lint_ignores) == expected_lint_ignores_length
+
+
+def test_extract_statement_lint_ignores_length() -> None:
+    """Test extract statement lint ignores length."""
     source_code: str = """
     -- noqa: NM016, GN001
     CREATE TABLE tbl (activated date);
     """
 
-    lint_ignores: list[noqa.NoQaDirective] = noqa.extract_lint_ignores(
-        source_file=TEST_FILE,
+    lint_ignores: list[noqa.NoQaDirective] = noqa.extract_statement_lint_ignores(
         source_code=source_code,
         statement=noqa.extract_statements(source_code=source_code)[0],
     )
 
-    expected_ignores_length: int = 2
+    expected_lint_ignores_length: int = 2
 
-    assert len(lint_ignores) == expected_ignores_length
+    assert len(lint_ignores) == expected_lint_ignores_length
 
 
-def test_wrongly_formed_inline_ignores_from_inline_comments(capfd: typing.Any) -> None:
-    """Test extract ignore from inline comments."""
+def test_wrongly_formed_lint_ignores(capfd: typing.Any) -> None:
+    """Test wrongly formed lint ignores."""
     source_code: str = """
     -- noqa NM016, GN001
     CREATE TABLE tbl (activated date);
     """
 
-    noqa.extract_lint_ignores(
-        source_file=TEST_FILE,
+    noqa.extract_statement_lint_ignores(
         source_code=source_code,
         statement=noqa.extract_statements(source_code=source_code)[0],
     )
@@ -89,8 +101,7 @@ def test_report_specific_unused_ignores(
     CREATE TABLE tbl (activated date);
     """
 
-    lint_ignores: list[noqa.NoQaDirective] = noqa.extract_lint_ignores(
-        source_file=TEST_FILE,
+    lint_ignores: list[noqa.NoQaDirective] = noqa.extract_statement_lint_ignores(
         source_code=source_code,
         statement=noqa.extract_statements(source_code=source_code)[0],
     )
@@ -103,17 +114,16 @@ def test_report_specific_unused_ignores(
     )
 
 
-def test_report_general_unused_ignores(
+def test_report_star_unused_ignores(
     capfd: typing.Any,
 ) -> None:
-    """Test report general unused ignores."""
+    """Test report star unused ignores."""
     source_code: str = """
     -- noqa
     CREATE TABLE tbl (activated date);
     """
 
-    lint_ignores: list[noqa.NoQaDirective] = noqa.extract_lint_ignores(
-        source_file=TEST_FILE,
+    lint_ignores: list[noqa.NoQaDirective] = noqa.extract_statement_lint_ignores(
         source_code=source_code,
         statement=noqa.extract_statements(source_code=source_code)[0],
     )


### PR DESCRIPTION
# Description

This PR adds support for skipping formatting of entire files using a directive at the top of the file, while also simplifying the statements extraction process by removing automatic semicolon addition and improving the naming consistency throughout the codebase.

Key changes include:

- Introduction of file-level format skip functionality using -- pgrubic: fmt: skip directive
- Refactoring of statement extraction to handle statements without automatically appending semicolons
- Renaming of functions and variables for better consistency (e.g., inline_ignores → lint_ignores)
- Improving column offset for noqa directives.