### PR TITLE
fix(linter): end of line mismatch causing fixes

### DIFF
--- a/src/pgrubic/core/linter.py
+++ b/src/pgrubic/core/linter.py
@@ -482,7 +482,9 @@ class Linter:
 
         fixed_source_code = None
 
-        if _fixed_source_code.encode("utf-8") != source_code.encode("utf-8"):
+        if _fixed_source_code.strip(noqa.NEW_LINE).encode("utf-8") != source_code.strip(
+            noqa.NEW_LINE,
+        ).encode("utf-8"):
             fixed_source_code = _fixed_source_code
 
         noqa.report_unused_ignores(

--- a/src/pgrubic/core/linter.py
+++ b/src/pgrubic/core/linter.py
@@ -482,7 +482,7 @@ class Linter:
 
         fixed_source_code = None
 
-        if _fixed_source_code.strip(noqa.NEW_LINE).encode("utf-8") != source_code.strip(
+        if _fixed_source_code.rstrip(noqa.NEW_LINE).encode("utf-8") != source_code.rstrip(
             noqa.NEW_LINE,
         ).encode("utf-8"):
             fixed_source_code = _fixed_source_code

--- a/src/pgrubic/core/linter.py
+++ b/src/pgrubic/core/linter.py
@@ -482,9 +482,9 @@ class Linter:
 
         fixed_source_code = None
 
-        if _fixed_source_code.rstrip(noqa.NEW_LINE).encode("utf-8") != source_code.rstrip(
+        if _fixed_source_code.rstrip(noqa.NEW_LINE) != source_code.rstrip(
             noqa.NEW_LINE,
-        ).encode("utf-8"):
+        ):
             fixed_source_code = _fixed_source_code
 
         noqa.report_unused_ignores(


### PR DESCRIPTION
When comparing the generated staged fixes and the source code, there are cases where the source code is missing a final new line and due to the fact that we add a final newline to the supposedly fixes, this triggers a fix which is not supposed to be. Now, we strip off the final newline from the both supposedly fix and the source code during comparison.