### PR TITLE
feat(linter): add support for linting SQL statements inside PostgreSQL DO blocks

### DIFF
--- a/src/pgrubic/core/do_block.py
+++ b/src/pgrubic/core/do_block.py
@@ -1,0 +1,205 @@
+"""DO block handling utilities for extracting and processing procedural code."""
+
+import logging
+import re
+from typing import Iterator, List, Optional, Tuple
+
+import pglast
+from pglast import ast
+
+# Import at runtime to avoid circular imports
+
+logger = logging.getLogger(__name__)
+
+
+def extract_do_block_body(do_stmt: ast.DoStmt) -> Optional[str]:
+    """Extract the body code from a DO statement.
+    
+    Args:
+        do_stmt: The DO statement AST node
+        
+    Returns:
+        The body code as a string, or None if not found
+    """
+    if not do_stmt.args:
+        return None
+        
+    for arg in do_stmt.args:
+        if isinstance(arg, ast.DefElem) and arg.defname == 'as':
+            # Extract string value from the arg
+            if hasattr(arg.arg, 'sval'):
+                return arg.arg.sval
+            elif isinstance(arg.arg, tuple) and len(arg.arg) > 0:
+                # Handle tuple case where the string is the first element
+                if hasattr(arg.arg[0], 'sval'):
+                    return arg.arg[0].sval
+    
+    return None
+
+
+def extract_sql_statements_from_plpgsql(body: str) -> List[Tuple[str, int]]:
+    """Extract SQL statements from PL/pgSQL code.
+    
+    This function identifies SQL statements within PL/pgSQL code by looking for
+    common SQL keywords and extracting statements up to their semicolons.
+    
+    Args:
+        body: The PL/pgSQL code body
+        
+    Returns:
+        List of tuples containing (sql_statement, line_offset)
+    """
+    statements = []
+    lines = body.split('\n')
+    
+    # SQL statement keywords that we want to extract
+    sql_keywords = {
+        'CREATE', 'ALTER', 'DROP', 'INSERT', 'UPDATE', 'DELETE', 'SELECT',
+        'GRANT', 'REVOKE', 'TRUNCATE', 'COMMENT', 'ANALYZE', 'VACUUM',
+        'EXPLAIN', 'LOCK', 'SET', 'RESET', 'SHOW', 'COPY', 'NOTIFY'
+    }
+    
+    i = 0
+    while i < len(lines):
+        line = lines[i].strip()
+        
+        # Skip empty lines and comments
+        if not line or line.startswith('--'):
+            i += 1
+            continue
+            
+        # Check if this line starts with a SQL keyword
+        first_word = line.split()[0].upper() if line.split() else ''
+        
+        if first_word in sql_keywords:
+            # Extract the full statement
+            statement_lines = []
+            line_offset = i
+            
+            # Collect lines until we find a semicolon at the statement level
+            paren_depth = 0
+            quote_char = None
+            dollar_quote = None
+            
+            while i < len(lines):
+                current_line = lines[i]
+                statement_lines.append(current_line)
+                
+                # Track nesting to handle semicolons inside parentheses/strings
+                j = 0
+                while j < len(current_line):
+                    char = current_line[j]
+                    
+                    # Handle dollar quotes
+                    if dollar_quote:
+                        if current_line[j:].startswith(dollar_quote):
+                            j += len(dollar_quote)
+                            dollar_quote = None
+                            continue
+                    elif char == '$' and j + 1 < len(current_line):
+                        # Check for dollar quote start
+                        match = re.match(r'\$([a-zA-Z_]*)\$', current_line[j:])
+                        if match:
+                            dollar_quote = match.group(0)
+                            j += len(dollar_quote)
+                            continue
+                    
+                    # Handle regular quotes
+                    if quote_char:
+                        if char == quote_char:
+                            # Check for escaped quote
+                            if j + 1 < len(current_line) and current_line[j + 1] == quote_char:
+                                j += 2
+                                continue
+                            quote_char = None
+                    elif char in ('"', "'"):
+                        quote_char = char
+                    
+                    # Track parentheses depth
+                    elif not quote_char and not dollar_quote:
+                        if char == '(':
+                            paren_depth += 1
+                        elif char == ')':
+                            paren_depth -= 1
+                        elif char == ';' and paren_depth == 0:
+                            # Found end of statement
+                            statement = '\n'.join(statement_lines)
+                            statements.append((statement, line_offset + 1))  # 1-based line numbers
+                            i += 1
+                            break
+                    
+                    j += 1
+                else:
+                    # Move to next line if we didn't find a semicolon
+                    i += 1
+                    if i >= len(lines):
+                        # Add incomplete statement if we reached end
+                        if statement_lines:
+                            statement = '\n'.join(statement_lines)
+                            statements.append((statement, line_offset + 1))
+                        break
+            else:
+                continue
+        else:
+            i += 1
+    
+    return statements
+
+
+def lint_do_block(linter: 'Linter', do_stmt: ast.DoStmt, source: str, filename: str, base_line: int = 1) -> Iterator['Violation']:
+    """Lint SQL statements within a DO block.
+    
+    Args:
+        linter: The linter instance to use
+        do_stmt: The DO statement AST node
+        source: The original source code
+        filename: The filename being linted
+        base_line: The line number where the DO block starts
+        
+    Yields:
+        Violations found within the DO block
+    """
+    # Extract the body code
+    body = extract_do_block_body(do_stmt)
+    if not body:
+        logger.debug("No body found in DO statement")
+        return
+    
+    # Extract SQL statements from the body
+    statements = extract_sql_statements_from_plpgsql(body)
+    
+    logger.debug(f"Found {len(statements)} SQL statements in DO block")
+    
+    # Lint each extracted statement
+    for sql, line_offset in statements:
+        try:
+            # Run the linter on the extracted SQL statement
+            result = linter.run(source_file=filename, source_code=sql)
+            
+            # Yield violations with adjusted line numbers
+            for violation in result.violations:
+                # Adjust the line number to account for the DO block offset
+                # We need to add the base_line and the offset within the DO block
+                adjusted_line = base_line + line_offset + violation.line_number - 2
+                
+                # Import here to avoid circular dependency
+                from pgrubic.core.linter import Violation
+                
+                yield Violation(
+                    rule_code=violation.rule_code,
+                    rule_name=violation.rule_name,
+                    rule_category=violation.rule_category,
+                    line_number=adjusted_line,
+                    column_offset=violation.column_offset,
+                    line=violation.line,
+                    statement_location=violation.statement_location,
+                    description=violation.description,
+                    is_auto_fixable=violation.is_auto_fixable,
+                    is_fix_enabled=violation.is_fix_enabled,
+                    help=violation.help
+                )
+                
+        except Exception as e:
+            logger.debug(f"Failed to parse SQL statement in DO block: {e}")
+            # Continue with other statements
+            continue

--- a/src/pgrubic/rules/do_block_mixin.py
+++ b/src/pgrubic/rules/do_block_mixin.py
@@ -1,0 +1,43 @@
+"""Mixin to add DO block support to checkers."""
+
+import logging
+from typing import Optional
+
+from pglast import ast, visitors
+
+from pgrubic.core import linter
+from pgrubic.core.do_block import lint_do_block
+
+logger = logging.getLogger(__name__)
+
+
+class DoBlockMixin:
+    """Mixin that adds DO block support to checkers.
+    
+    Any checker that wants to lint SQL statements inside DO blocks should
+    inherit from both BaseChecker and this mixin.
+    """
+    
+    def visit_DoStmt(
+        self: linter.BaseChecker,
+        ancestors: visitors.Ancestor,
+        node: ast.DoStmt,
+    ) -> None:
+        """Visit DO statement and lint SQL statements within it."""
+        # Create a temporary linter instance with just this checker
+        temp_linter = linter.Linter(
+            config=self.config,
+            formatters=lambda: set()  # No formatters needed for nested linting
+        )
+        temp_linter.checkers = {self.__class__()}
+        
+        # Lint the DO block and collect violations
+        for violation in lint_do_block(
+            linter=temp_linter,
+            do_stmt=node,
+            source=self.source_code,
+            filename=self.source_file,
+            base_line=self.line_number
+        ):
+            # Add the violation directly as it's already in the correct format
+            self.violations.add(violation)

--- a/tests/test_do_block.py
+++ b/tests/test_do_block.py
@@ -1,0 +1,380 @@
+"""Test DO block linting functionality."""
+
+from pgrubic import core
+
+
+def test_do_block_sql_statement_linting(linter: core.Linter):
+    """Test that SQL statements inside DO blocks are properly linted."""
+    
+    # Create a DO block with SQL statements that should trigger violations
+    do_block_sql = '''
+DO
+$$
+BEGIN
+    CREATE TABLE test_table (
+        id uuid NOT NULL,
+        name character varying(254),
+        created_at TIMESTAMP(3) NOT NULL DEFAULT now()
+    );
+    
+    ALTER TABLE test_table ADD column_with_json json;
+END;
+$$
+LANGUAGE plpgsql;
+'''
+    
+    # Lint the DO block
+    result = linter.run(source_file="test_do_block.sql", source_code=do_block_sql)
+    
+    # Check that violations were found
+    assert len(result.violations) > 0, "Expected violations to be found in DO block"
+    
+    # Check for specific violations we expect:
+    violation_codes = {v.rule_code for v in result.violations}
+    
+    # Should find TP005 (varchar), TP001 (timestamp without timezone), 
+    # GN017 (id column), TP008 (json vs jsonb)
+    expected_violations = {"TP005", "TP001", "GN017", "TP008"}
+    found_violations = violation_codes & expected_violations
+    
+    assert len(found_violations) > 0, f"Expected to find violations {expected_violations}, but only found {violation_codes}"
+    
+    # Verify line numbers are reasonable (they should be > 1 since violations are in the DO block body)
+    line_numbers = [v.line_number for v in result.violations]
+    assert all(line_num > 1 for line_num in line_numbers), f"Expected line numbers > 1, got {line_numbers}"
+
+
+def test_do_block_without_sql_statements(linter: core.Linter):
+    """Test that DO blocks without SQL statements don't cause issues."""
+    
+    # Create a DO block with only procedural code
+    do_block_sql = '''
+DO
+$$
+BEGIN
+    RAISE NOTICE 'Hello World';
+    IF 1 = 1 THEN
+        RAISE NOTICE 'True condition';
+    END IF;
+END;
+$$
+LANGUAGE plpgsql;
+'''
+    
+    result = linter.run(source_file="test_procedural.sql", source_code=do_block_sql)
+    
+    # Should not find any violations (no SQL statements to lint)
+    # This also verifies the DO block parser doesn't crash on procedural code
+    assert len(result.violations) == 0, f"Expected no violations, but found {len(result.violations)}"
+    assert len(result.errors) == 0, f"Expected no errors, but found {result.errors}"
+
+
+def test_mixed_do_block_and_regular_statements(linter: core.Linter):
+    """Test linting file with both DO blocks and regular SQL statements."""
+    
+    mixed_sql = '''
+CREATE TABLE regular_table (
+    id uuid NOT NULL,
+    data character varying(100)
+);
+
+DO
+$$
+BEGIN
+    CREATE TABLE do_block_table (
+        id uuid NOT NULL,
+        info character varying(200)
+    );
+END;
+$$
+LANGUAGE plpgsql;
+
+ALTER TABLE regular_table ADD created_at TIMESTAMP(3);
+'''
+    
+    result = linter.run(source_file="test_mixed.sql", source_code=mixed_sql)
+    
+    # Should find violations from both regular SQL and DO block SQL
+    assert len(result.violations) > 0, "Expected violations from both regular and DO block statements"
+    
+    # Check that we get violations from multiple statements
+    violation_codes = {v.rule_code for v in result.violations}
+    expected_violations = {"TP005", "TP001", "GN017"}  # varchar, timestamp, id column
+    found_violations = violation_codes & expected_violations
+    
+    assert len(found_violations) > 0, f"Expected violations {expected_violations}, found {violation_codes}"
+
+
+def test_multiple_separate_do_blocks(linter: core.Linter):
+    """Test multiple separate DO blocks in the same file."""
+    
+    # Multiple DO blocks as separate statements
+    multiple_do_sql = '''
+-- First DO block
+DO
+$$
+BEGIN
+    CREATE TABLE first_table (
+        id uuid NOT NULL,
+        name character varying(100)
+    );
+END;
+$$
+LANGUAGE plpgsql;
+
+-- Second DO block  
+DO
+$$
+BEGIN
+    CREATE TABLE second_table (
+        id uuid NOT NULL,
+        description character varying(200),
+        created_at TIMESTAMP(3) NOT NULL DEFAULT now()
+    );
+    
+    ALTER TABLE second_table ADD status_json json;
+END;
+$$
+LANGUAGE plpgsql;
+
+-- Third DO block
+DO
+$$
+BEGIN
+    ALTER TABLE first_table ADD updated_at TIMESTAMP(3);
+    ALTER TABLE second_table ADD modified_by character varying(255);
+END;
+$$
+LANGUAGE plpgsql;
+'''
+    
+    result = linter.run(source_file="test_multiple_do.sql", source_code=multiple_do_sql)
+    
+    # Should find violations from all DO blocks
+    assert len(result.violations) > 0, "Expected violations to be found in multiple DO blocks"
+    
+    # Check for violations we expect from all blocks
+    violation_codes = {v.rule_code for v in result.violations}
+    expected_violations = {"TP005", "TP001", "GN017", "TP008"}  # varchar, timestamp, id column, json
+    found_violations = violation_codes & expected_violations
+    
+    assert len(found_violations) >= 3, f"Expected multiple violations {expected_violations}, found {violation_codes}"
+    
+    # Should have violations from all three DO blocks
+    # We expect violations from CREATE TABLE statements in first and second blocks,
+    # plus ALTER TABLE statements in all blocks
+
+
+def test_do_block_with_dynamic_sql(linter: core.Linter):
+    """Test DO blocks that mix static SQL with dynamic EXECUTE statements."""
+    
+    dynamic_sql = '''
+DO
+$$
+BEGIN
+    -- Static SQL that should be linted
+    CREATE TABLE static_table (
+        id uuid NOT NULL,
+        data character varying(500)
+    );
+    
+    -- Dynamic SQL that should not be parsed (it's a string)
+    EXECUTE 'CREATE TABLE dynamic_table (bad_id varchar(50))';
+    
+    -- More static SQL
+    ALTER TABLE static_table ADD created_at TIMESTAMP(3);
+END;
+$$
+LANGUAGE plpgsql;
+'''
+    
+    result = linter.run(source_file="test_dynamic.sql", source_code=dynamic_sql)
+    
+    # Should find violations from static SQL only
+    assert len(result.violations) > 0, "Expected violations from static SQL in DO block"
+    
+    violation_codes = {v.rule_code for v in result.violations}
+    expected_violations = {"TP005", "TP001", "GN017"}  # varchar, timestamp, id column
+    found_violations = violation_codes & expected_violations
+    
+    # Should find violations from the static CREATE TABLE and ALTER TABLE
+    assert len(found_violations) > 0, f"Expected violations {expected_violations}, found {violation_codes}"
+    
+    # The dynamic SQL in EXECUTE should not be linted (it's just a string literal)
+    # This is correct behavior since dynamic SQL can't be statically analyzed
+
+
+def test_do_block_creating_function_with_nested_structure(linter: core.Linter):
+    """Test DO block that creates a function, simulating nested procedural structures."""
+    
+    function_creation_sql = '''
+DO
+$$
+BEGIN
+    -- Create a table first
+    CREATE TABLE function_test_table (
+        id uuid NOT NULL,
+        name character varying(150)
+    );
+    
+    -- Create a function that would have its own procedural logic
+    -- (Note: The function body is a string, so won't be parsed as separate DO block)
+    EXECUTE 'CREATE OR REPLACE FUNCTION test_function()
+    RETURNS void AS $func$
+    BEGIN
+        -- This is inside the function body string
+        INSERT INTO function_test_table (id, name) VALUES (gen_random_uuid(), ''test'');
+    END;
+    $func$ LANGUAGE plpgsql;';
+    
+    -- More direct SQL in the DO block
+    ALTER TABLE function_test_table ADD created_at TIMESTAMP(3);
+    ALTER TABLE function_test_table ADD data_json json;
+END;
+$$
+LANGUAGE plpgsql;
+'''
+    
+    result = linter.run(source_file="test_function_creation.sql", source_code=function_creation_sql)
+    
+    # Should find violations from the direct SQL in the DO block
+    assert len(result.violations) > 0, "Expected violations from SQL in DO block"
+    
+    violation_codes = {v.rule_code for v in result.violations}
+    expected_violations = {"TP005", "TP001", "GN017", "TP008"}  # varchar, timestamp, id, json
+    found_violations = violation_codes & expected_violations
+    
+    # Should find violations from CREATE TABLE and ALTER TABLE statements
+    assert len(found_violations) > 0, f"Expected violations {expected_violations}, found {violation_codes}"
+    
+    # The function body in EXECUTE is dynamic SQL (string) so won't be parsed
+    # This is the correct behavior for PostgreSQL static analysis
+
+
+def test_complex_do_block_with_transactions_and_conditionals(linter: core.Linter):
+    """Test complex DO block with conditional SQL and transaction control."""
+    
+    complex_sql = '''
+DO
+$$
+DECLARE
+    table_exists boolean;
+BEGIN
+    -- Check if table exists (this is valid PL/pgSQL)
+    SELECT EXISTS (
+        SELECT FROM information_schema.tables 
+        WHERE table_name = 'complex_table'
+    ) INTO table_exists;
+    
+    -- Conditional table creation
+    IF NOT table_exists THEN
+        CREATE TABLE complex_table (
+            id uuid NOT NULL,
+            legacy_name character varying(300),
+            created_at TIMESTAMP(3) NOT NULL DEFAULT now()
+        );
+    END IF;
+    
+    -- Always add these columns
+    ALTER TABLE complex_table ADD COLUMN IF NOT EXISTS status_data json;
+    ALTER TABLE complex_table ADD COLUMN IF NOT EXISTS updated_at TIMESTAMP(3);
+    
+    -- Create an index
+    CREATE INDEX IF NOT EXISTS idx_complex_name ON complex_table (legacy_name);
+    
+    RAISE NOTICE 'Complex DO block completed';
+END;
+$$
+LANGUAGE plpgsql;
+'''
+    
+    result = linter.run(source_file="test_complex_do.sql", source_code=complex_sql)
+    
+    # Should find violations from SQL statements within the conditional blocks
+    assert len(result.violations) > 0, "Expected violations from complex DO block"
+    
+    violation_codes = {v.rule_code for v in result.violations}
+    
+    # We might get different violations depending on the rules enabled
+    # The key thing is that we're detecting SQL within the complex DO block structure
+    # Check for some expected violations (adjust based on what's actually found)
+    possible_violations = {"TP005", "TP001", "GN017", "TP008", "GN014", "SM001"}  
+    found_violations = violation_codes & possible_violations
+    
+    assert len(found_violations) > 0, f"Expected some violations from {possible_violations}, found {violation_codes}"
+    
+    # This tests that our SQL extraction logic can handle:
+    # - DECLARE sections
+    # - Conditional blocks (IF/THEN/END IF)
+    # - Mixed procedural and SQL statements
+    # - Complex nested structures
+
+
+def test_real_world_migration_script(linter: core.Linter):
+    """Test a real-world migration script with complex DO block structure."""
+    
+    # This is based on an actual migration script provided by the user
+    migration_sql = '''
+DO
+$$
+begin
+    -- Move emails and phoneNumbers to base_customer entity
+    -- 1.a add new fields
+  IF NOT EXISTS (SELECT * FROM information_schema."columns" WHERE table_schema = 'account' AND table_name = 'base_customer' AND column_name = 'emails') THEN
+        ALTER TABLE "account"."base_customer" ADD "emails" json;
+        COMMENT ON COLUMN "account"."base_customer"."emails" IS 'sensitive';
+    END IF;
+
+  IF NOT EXISTS (SELECT * FROM information_schema."columns" WHERE table_schema = 'account' AND table_name = 'base_customer' AND column_name = 'phoneNumbers') THEN
+        ALTER TABLE "account"."base_customer" ADD "phoneNumbers" json;
+        COMMENT ON COLUMN "account"."base_customer"."phoneNumbers" IS 'sensitive';
+    END IF;
+
+    -- 1.b copy data across
+    UPDATE account.base_customer bc
+    SET emails = ic.emails,
+    "phoneNumbers" = ic."phoneNumbers"
+    FROM account.individual_customer ic
+    WHERE ic."baseCustomerId" = bc.id ;
+
+    -- 2.a create new table with new schema
+    CREATE TABLE IF NOT EXISTS "account"."individual_customer_new" (
+        "createCorrelationId" uuid NOT NULL,
+        "createdAt" TIMESTAMP(3) NOT NULL DEFAULT now(),
+        "updateCorrelationId" uuid,
+        "updatedAt" TIMESTAMP(3),
+        "id" uuid NOT NULL,
+        "givenName" character varying(254),
+        "familyName" character varying(254),
+        "dateOfBirth" date,
+        "maritalStatus" "core"."customermaritalstatustype_enum" NOT NULL,
+        "gender" "core"."customergendertype_enum" NOT NULL,
+        CONSTRAINT "PK_account.IndividualCustomer2" PRIMARY KEY ("id"),
+         CONSTRAINT "FK_IndividualCustomer_id" FOREIGN KEY ("id") REFERENCES "account"."base_customer"("id") ON DELETE NO ACTION ON UPDATE NO ACTION
+    ); 
+END;
+$$
+LANGUAGE plpgsql;
+'''
+    
+    result = linter.run(source_file="real_migration.sql", source_code=migration_sql)
+    
+    # Should find violations from the SQL within the complex DO block
+    # Note: The exact number depends on how many SQL statements our extraction logic finds
+    assert len(result.violations) > 0, f"Expected violations from complex migration, found {len(result.violations)}"
+    
+    violation_codes = {v.rule_code for v in result.violations}
+    
+    # The key requirement is that we find violations within the DO block
+    # This proves our SQL extraction and linting is working
+    
+    # We should at least find violations from the SQL within the DO block
+    assert "TP008" in violation_codes, f"Expected TP008 (json) violation, found {violation_codes}"
+    
+    # This test verifies that complex real-world migration scripts with:
+    # - Conditional table modifications
+    # - Data migration UPDATE statements  
+    # - Complex CREATE TABLE with constraints
+    # - Mixed procedural and SQL logic
+    # - Multiple nested IF blocks
+    # Are properly parsed and linted

--- a/tests/test_pglogical_do_blocks.py
+++ b/tests/test_pglogical_do_blocks.py
@@ -1,0 +1,111 @@
+"""Test pglogical nested DO block patterns."""
+
+from pgrubic import core
+
+
+def test_pglogical_nested_do_block_current_behavior(linter: core.Linter):
+    """Test current behavior with pglogical nested DO blocks."""
+    
+    # This represents the realistic production pattern
+    pglogical_sql = '''
+SELECT pglogical.replicate_ddl_command(
+$$
+    DO
+    $script$
+    BEGIN
+        -- This ALTER TABLE should ideally be linted, but currently isn't
+        ALTER TABLE "account"."test_table" ADD "badColumn" character varying(500);
+        
+        -- This one too
+        CREATE TABLE "account"."bad_table" (
+            "id" uuid NOT NULL,
+            "createdAt" TIMESTAMP(3) NOT NULL DEFAULT now()
+        );
+    END
+    $script$
+    LANGUAGE plpgsql;
+$$,
+'{global}'::text[]);
+'''
+    
+    result = linter.run(source_file="pglogical_test.sql", source_code=pglogical_sql)
+    
+    # Current behavior: this is parsed as a SELECT statement, not a DO block
+    # So we expect no violations to be found (the DO block is embedded in a string)
+    
+    print(f"DEBUG: Found {len(result.violations)} violations")
+    print(f"DEBUG: Found {len(result.errors)} errors")
+    
+    # Document current limitation: nested DO blocks in function calls aren't linted
+    # This is expected behavior since the DO block exists as string data
+    assert len(result.errors) <= 1, "Should handle gracefully without major errors"
+    
+    # The violations list will likely be empty since the SQL inside the string
+    # parameter isn't parsed as separate statements
+    violation_codes = {v.rule_code for v in result.violations}
+    print(f"DEBUG: Violation codes: {violation_codes}")
+
+
+def test_standalone_do_block_still_works(linter: core.Linter):
+    """Verify that standalone DO blocks still work after pglogical test."""
+    
+    # Ensure our core functionality still works
+    standalone_sql = '''
+DO
+$$
+BEGIN
+    CREATE TABLE "test_table" (
+        "id" uuid NOT NULL,
+        "name" character varying(254)
+    );
+END
+$$
+LANGUAGE plpgsql;
+'''
+    
+    result = linter.run(source_file="standalone_test.sql", source_code=standalone_sql)
+    
+    # This should still find violations (TP005 for varchar, GN017 for id)
+    assert len(result.violations) > 0, "Standalone DO blocks should still be linted"
+    
+    violation_codes = {v.rule_code for v in result.violations}
+    expected_violations = {"TP005", "GN017"}  # varchar, id column
+    found_violations = violation_codes & expected_violations
+    
+    assert len(found_violations) > 0, f"Expected {expected_violations}, found {violation_codes}"
+
+
+def test_documentation_of_pglogical_limitation():
+    """Document the current limitation with nested DO blocks."""
+    
+    limitation_doc = """
+    CURRENT LIMITATION: Nested DO blocks in function calls
+    
+    The following pattern is NOT currently supported for linting:
+    
+    SELECT pglogical.replicate_ddl_command(
+    $$
+        DO $script$
+        BEGIN
+            -- SQL here won't be linted
+        END
+        $script$ LANGUAGE plpgsql;
+    $$,
+    '{global}'::text[]);
+    
+    WORKAROUND: Extract the DO block to a standalone statement:
+    
+    DO $script$
+    BEGIN
+        -- SQL here WILL be linted
+    END
+    $script$ LANGUAGE plpgsql;
+    
+    Then wrap it in pglogical call if needed for deployment.
+    
+    REASON: The DO block exists as string data within a function parameter,
+    not as a parsed DO statement that our current implementation can detect.
+    """
+    
+    # This test documents the limitation for users
+    assert True, limitation_doc


### PR DESCRIPTION
This enhancement enables `pgrubic` to detect and lint SQL statements within PostgreSQL `DO` blocks and other procedural constructs, significantly improving support for real-world PostgreSQL migration scripts.

Key changes:
- Add DO block detection and SQL extraction in `src/pgrubic/core/do_block.py`
- Integrate DO block processing into main linting pipeline in `src/pgrubic/core/linter.py`
- Add comprehensive test coverage for various `DO` block scenarios
- Support complex procedural constructs with conditional logic (`IF/THEN/END IF`)
- Maintain accurate line number mapping for error reporting
- Preserve all existing functionality with zero breaking changes

Supported patterns:
- Simple `DO` blocks with SQL statements
- Complex migration scripts with conditional schema changes
- Multiple `DO` blocks in the same file
- Mixed procedural and SQL code
- `DO` blocks with `DECLARE` sections and control flow

All existing linting rules automatically apply to SQL within DO blocks. This resolves the issue where DO blocks were ignored and reported "All checks passed\!" instead of finding violations in the contained SQL statements.

Closes #120