### PR TITLE
fix(linter): ensure fixes are tracked on statement and file level, ensure unfixed statement are not discarded

### DIFF
--- a/tests/test_linter.py
+++ b/tests/test_linter.py
@@ -58,12 +58,15 @@ def test_linter_violations_fixed_source_code(
     linting_result = linter.run(
         source_file=SOURCE_FILE,
         source_code="""
-        SELECT a = NULL;
-        SELECT b IS NULL;
-        """,
+SELECT a = NULL;
+SELECT b IS NULL;
+""",
     )
 
-    assert linting_result.fixed_source_code == f"SELECT a IS NULL;{noqa.NEW_LINE}"
+    assert (
+        linting_result.fixed_source_code
+        == f"SELECT a IS NULL;{noqa.NEW_LINE}{noqa.NEW_LINE}SELECT b IS NULL;{noqa.NEW_LINE}"  # noqa: E501
+    )
 
 
 def test_linter_violations_no_fixed_source_code(

--- a/tests/test_linter.py
+++ b/tests/test_linter.py
@@ -57,7 +57,10 @@ def test_linter_violations_fixed_source_code(
     linter.config.lint.fix = True
     linting_result = linter.run(
         source_file=SOURCE_FILE,
-        source_code="SELECT a = NULL;",
+        source_code="""
+        SELECT a = NULL;
+        SELECT b IS NULL;
+        """,
     )
 
     assert linting_result.fixed_source_code == f"SELECT a IS NULL;{noqa.NEW_LINE}"


### PR DESCRIPTION
## Pull Request Overview

This PR fixes the generation of fixes in the linter by implementing proper tracking of applied fixes at both statement and file levels. The change replaces a simple boolean list with dedicated counters to better manage fix state across multiple statements.

Key changes:
- Introduces a `FixCounter` class to track fixes with increment and reset functionality
- Replaces the boolean `applied_fixes` list with separate `statement_fixes` and `file_fixes` counters
- Updates the fix generation logic to properly handle multiple statements with fixes