### PR TITLE
build(deps): sync docker base images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ COPY pyproject.toml ./
 RUN tox -e build-dist
 
 # Stage 2: Runtime
-FROM python:3.13-slim
+FROM python:3.13-slim@sha256:6544e0e002b40ae0f59bc3618b07c1e48064c4faed3a15ae2fbd2e8f663e8283 AS runtime
 
 WORKDIR /app
 


### PR DESCRIPTION
## Pull Request Overview

This PR updates the Docker base image to use a pinned SHA256 digest for improved reproducibility and security. The change ensures that builds use a specific, immutable version of the python:3.13-slim image rather than relying on the latest tagged version.

- Pins the python:3.13-slim base image to a specific SHA256 digest
- Adds an explicit stage name "runtime" for the final build stage



