### PR TITLE
docs: hide module level function

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -23,6 +23,7 @@ plugins:
               - "!^visit"
               - "!^is_fix_applicable"
               - "!^is_fix_enabled"
+              - "!^disable_auto_fix"
   - search
 
 theme:

--- a/src/pgrubic/rules/typing/TP017.py
+++ b/src/pgrubic/rules/typing/TP017.py
@@ -7,7 +7,7 @@ from pgrubic.core import linter
 
 class NullableBooleanField(linter.BaseChecker):
     """## **What it does**
-    Checks for nullable boolean field.
+    Checks for nullable boolean fields.
 
     ## **Why not?**
     3 possible values is not a boolean. By allowing nulls in a boolean field, you are

--- a/src/pgrubic/rules/typing/TP017.py
+++ b/src/pgrubic/rules/typing/TP017.py
@@ -7,7 +7,7 @@ from pgrubic.core import linter
 
 class NullableBooleanField(linter.BaseChecker):
     """## **What it does**
-    Checks for usage of numeric with precision.
+    Checks for nullable boolean field.
 
     ## **Why not?**
     3 possible values is not a boolean. By allowing nulls in a boolean field, you are


### PR DESCRIPTION
## Pull Request Overview

This PR updates documentation by hiding a module-level function and correcting a docstring description. The changes focus on improving documentation clarity and consistency.

- Corrects the docstring description for `NullableBooleanField` class to accurately reflect its purpose
- Hides the `disable_auto_fix` function from documentation generation