### PR TITLE
feat(rule): add rules for security definer functions

### DIFF
--- a/docs/docs/rules.md
+++ b/docs/docs/rules.md
@@ -95,6 +95,9 @@ There are **100+** rules and all rules are enabled by default. Rule are divided 
 | ------| ---------------------------------------------------------------------------------|------------------- |--------------|
 | ST001 | [extension-whitelist](rules/security/extension-whitelist.md)                     | :white_check_mark: | :x:          |
 | ST002 | [procedural-language-whitelist](rules/security/procedural-language-whitelist.md) | :white_check_mark: | :x:          |
+| ST003 | [security-definer-function-no-explicit-search-path](rules/security/security-definer-function-no-explicit-search-path.md)                             | :white_check_mark: | :white_check_mark: |
+| ST004 | [security-definer-function-temp-schema-order](rules/security/security-definer-function-temp-schema-order.md) | :white_check_mark: | :white_check_mark: |
+| ST005 | [security-definer-function-non-temp-schema](rules/security/security-definer-function-non-temp-schema.md) | :white_check_mark: | :white_check_mark: |
 
 ## typing (TP)
 

--- a/docs/docs/rules/security/security-definer-function-no-explicit-search-path.md
+++ b/docs/docs/rules/security/security-definer-function-no-explicit-search-path.md
@@ -1,0 +1,5 @@
+# security-definer-function-no-explicit-search-path (ST003)
+
+Automatic fix is available.
+
+::: pgrubic.rules.security.ST003.SecurityDefinerFunctionNoExplicitSearchPath

--- a/docs/docs/rules/security/security-definer-function-non-temp-schema.md
+++ b/docs/docs/rules/security/security-definer-function-non-temp-schema.md
@@ -1,0 +1,5 @@
+# security-definer-function-non-temp-schema (ST005)
+
+Automatic fix is available.
+
+::: pgrubic.rules.security.ST005.SecurityDefinerFunctionNonTempSchema

--- a/docs/docs/rules/security/security-definer-function-temp-schema-order.md
+++ b/docs/docs/rules/security/security-definer-function-temp-schema-order.md
@@ -1,0 +1,5 @@
+# security-definer-function-temp-schema-order (ST004)
+
+Automatic fix is available.
+
+::: pgrubic.rules.security.ST004.SecurityDefinerFunctionTempSchemaOrder

--- a/src/pgrubic/core/__init__.py
+++ b/src/pgrubic/core/__init__.py
@@ -1,6 +1,6 @@
 """Core functionalities."""
 
-from pgrubic.core import cache, config, visitors
+from pgrubic.core import cache, enums, config, visitors
 from pgrubic.core.cache import Cache
 from pgrubic.core.config import Config, parse_config
 from pgrubic.core.linter import Linter, BaseChecker, ViolationStats
@@ -18,6 +18,7 @@ __all__ = [
     "ViolationStats",
     "cache",
     "config",
+    "enums",
     "filter_sources",
     "load_formatters",
     "load_rules",

--- a/src/pgrubic/core/enums.py
+++ b/src/pgrubic/core/enums.py
@@ -1,0 +1,11 @@
+"""Enums."""
+
+import enum
+
+
+class FunctionOption(enum.StrEnum):
+    """Function option."""
+
+    SECURITY = enum.auto()
+    LANGUAGE = enum.auto()
+    SET = enum.auto()

--- a/src/pgrubic/rules/security/ST002.py
+++ b/src/pgrubic/rules/security/ST002.py
@@ -11,7 +11,7 @@ class ProceduralLanguageWhitelist(linter.BaseChecker):
 
     ## **Why not?**
     By default, any procedural language can be loaded into the database.
-    This is quite dangerous as some unsafe operations might be introuduced by languages.
+    This is quite dangerous as some unsafe operations might be introduced by languages.
     So you not only want to empower **CREATE LANGUAGE** to database owners, you
     also want to be able to review and explicitly allow procedural languages.
 

--- a/src/pgrubic/rules/security/ST003.py
+++ b/src/pgrubic/rules/security/ST003.py
@@ -1,0 +1,22 @@
+"""Checker for security definer functions without explicit search path."""
+
+from pgrubic.core import linter
+
+
+class SecurityDefinerFunctionWithoutSearchPath(linter.BaseChecker):
+    """## **What it does**
+    Checks that a security definer function to be created has an explicit search path.
+
+    ## **Why not?**
+    Because a **SECURITY DEFINER** function is executed with the privileges of the user
+    that owns it, care is needed to ensure that the function cannot be misused.
+    For security, **search_path** should be set to exclude any schemas writable by
+    untrusted users. This prevents malicious users from creating objects (e.g., tables,
+    functions, and operators) that mask objects intended to be used by the function.
+
+    ## **When should you?**
+    Never.
+
+    ## **Use instead:**
+    Always set **search_path** on a SECURITY DEFINER function.
+    """

--- a/src/pgrubic/rules/security/ST003.py
+++ b/src/pgrubic/rules/security/ST003.py
@@ -1,11 +1,13 @@
-"""Checker for security definer functions without explicit search path."""
+"""Checker for security definer functions without search path."""
+
+from pglast import ast, visitors
 
 from pgrubic.core import linter
 
 
 class SecurityDefinerFunctionWithoutSearchPath(linter.BaseChecker):
     """## **What it does**
-    Checks that a security definer function to be created has an explicit search path.
+    Checks that a security definer function has a search path.
 
     ## **Why not?**
     Because a **SECURITY DEFINER** function is executed with the privileges of the user
@@ -20,3 +22,37 @@ class SecurityDefinerFunctionWithoutSearchPath(linter.BaseChecker):
     ## **Use instead:**
     Always set **search_path** on a SECURITY DEFINER function.
     """
+
+    def visit_CreateFunctionStmt(
+        self,
+        ancestors: visitors.Ancestor,
+        node: ast.CreateFunctionStmt,
+    ) -> None:
+        """Visit a CreateFunctionStmt."""
+        is_security_definer = False
+        has_search_path = False
+
+        for option in node.options:
+            name = option.defname.upper()
+            if name == "SECURITY" and option.arg.boolval:
+                is_security_definer = True
+
+            if name == "SET" and option.arg.name == "search_path":
+                has_search_path = True
+
+        if is_security_definer and not has_search_path:
+            self.violations.add(
+                linter.Violation(
+                    rule_code=self.code,
+                    rule_name=self.name,
+                    rule_category=self.category,
+                    line_number=self.line_number,
+                    column_offset=self.column_offset,
+                    line=self.line,
+                    statement_location=self.statement_location,
+                    description="Security definer function without search path",
+                    is_auto_fixable=self.is_auto_fixable,
+                    is_fix_enabled=self.is_fix_enabled,
+                    help="Set search_path on security definer functions",
+                ),
+            )

--- a/src/pgrubic/rules/security/ST003.py
+++ b/src/pgrubic/rules/security/ST003.py
@@ -76,6 +76,7 @@ class SecurityDefinerFunctionNoExplicitSearchPath(linter.BaseChecker):
             for option in typing.cast(tuple[ast.DefElem], node.options)
             if not (
                 option.defname == enums.FunctionOption.SET
+                and isinstance(option.arg, ast.VariableSetStmt)
                 and option.arg.name == "search_path"
             )
         )

--- a/src/pgrubic/rules/security/ST003.py
+++ b/src/pgrubic/rules/security/ST003.py
@@ -45,8 +45,8 @@ class SecurityDefinerFunctionNoExplicitSearchPath(linter.BaseChecker):
             if (
                 name == enums.FunctionOption.SET
                 and isinstance(option.arg, ast.VariableSetStmt)
-                and option.arg.kind == pglast_enums.VariableSetKind.VAR_SET_VALUE
                 and option.arg.name == "search_path"
+                and option.arg.kind == pglast_enums.VariableSetKind.VAR_SET_VALUE
             ):
                 has_explicit_search_path = True
 

--- a/src/pgrubic/rules/security/ST003.py
+++ b/src/pgrubic/rules/security/ST003.py
@@ -44,9 +44,9 @@ class SecurityDefinerFunctionNoExplicitSearchPath(linter.BaseChecker):
 
             if (
                 name == enums.FunctionOption.SET
-                and option.arg.name == "search_path"
                 and isinstance(option.arg, ast.VariableSetStmt)
                 and option.arg.kind == pglast_enums.VariableSetKind.VAR_SET_VALUE
+                and option.arg.name == "search_path"
             ):
                 has_explicit_search_path = True
 

--- a/src/pgrubic/rules/security/ST004.py
+++ b/src/pgrubic/rules/security/ST004.py
@@ -52,8 +52,8 @@ class SecurityDefinerFunctionTempSchemaOrder(linter.BaseChecker):
             if (
                 name == enums.FunctionOption.SET
                 and isinstance(option.arg, ast.VariableSetStmt)
-                and option.arg.kind == pglast_enums.VariableSetKind.VAR_SET_VALUE
                 and option.arg.name == "search_path"
+                and option.arg.kind == pglast_enums.VariableSetKind.VAR_SET_VALUE
             ):
                 has_explicit_search_path = True
                 last_entry_in_search_path = option.arg.args[-1].val.sval

--- a/src/pgrubic/rules/security/ST004.py
+++ b/src/pgrubic/rules/security/ST004.py
@@ -86,6 +86,7 @@ class SecurityDefinerFunctionTempSchemaOrder(linter.BaseChecker):
         for option in typing.cast(tuple[ast.DefElem], node.options):
             if (
                 option.defname == enums.FunctionOption.SET
+                and isinstance(option.arg, ast.VariableSetStmt)
                 and option.arg.name == "search_path"
             ):
                 non_temp_schemas = tuple(

--- a/src/pgrubic/rules/security/ST004.py
+++ b/src/pgrubic/rules/security/ST004.py
@@ -52,8 +52,8 @@ class SecurityDefinerFunctionTempSchemaOrder(linter.BaseChecker):
             if (
                 name == enums.FunctionOption.SET
                 and isinstance(option.arg, ast.VariableSetStmt)
-                and option.arg.name == "search_path"
                 and option.arg.kind == pglast_enums.VariableSetKind.VAR_SET_VALUE
+                and option.arg.name == "search_path"
             ):
                 has_explicit_search_path = True
                 last_entry_in_search_path = option.arg.args[-1].val.sval

--- a/src/pgrubic/rules/security/ST004.py
+++ b/src/pgrubic/rules/security/ST004.py
@@ -56,7 +56,8 @@ class SecurityDefinerFunctionTempSchemaOrder(linter.BaseChecker):
                 and option.arg.kind == pglast_enums.VariableSetKind.VAR_SET_VALUE
             ):
                 has_explicit_search_path = True
-                last_entry_in_search_path = option.arg.args[-1].val.sval
+                if option.arg.args:
+                    last_entry_in_search_path = option.arg.args[-1].val.sval
 
         if (
             is_security_definer

--- a/src/pgrubic/rules/security/ST004.py
+++ b/src/pgrubic/rules/security/ST004.py
@@ -56,6 +56,7 @@ class SecurityDefinerFunctionTempSchemaOrder(linter.BaseChecker):
                 and option.arg.kind == pglast_enums.VariableSetKind.VAR_SET_VALUE
             ):
                 has_explicit_search_path = True
+
                 if option.arg.args:
                     last_entry_in_search_path = option.arg.args[-1].val.sval
 

--- a/src/pgrubic/rules/security/ST004.py
+++ b/src/pgrubic/rules/security/ST004.py
@@ -1,0 +1,86 @@
+"""Checker for security definer functions without pg_temp as the last element in the
+search path.
+"""
+
+import typing
+
+from pglast import ast, visitors
+
+from pgrubic.core import linter
+
+
+class SecurityDefinerFunctionWithoutPgTempAsLastElementInSearchPath(linter.BaseChecker):
+    """## **What it does**
+    Checks that a security definer function has pg_temp as the last element in the search
+    path.
+
+    ## **Why not?**
+    Because a **SECURITY DEFINER** function is executed with the privileges of the user
+    that owns it, care is needed to ensure that the function cannot be misused.
+    For security, **search_path** should be set to exclude any schemas writable by
+    untrusted users. This prevents malicious users from creating objects (e.g., tables,
+    functions, and operators) that mask objects intended to be used by the function.
+    A secure arrangement can be obtained by forcing the temporary schema to be searched
+    last.
+
+    ## **When should you?**
+    Never.
+
+    ## **Use instead:**
+    Always include **pg_temp** as the last element in **search_path** on a SECURITY
+    DEFINER function.
+    """
+
+    is_auto_fixable = True
+
+    def visit_CreateFunctionStmt(
+        self,
+        ancestors: visitors.Ancestor,
+        node: ast.CreateFunctionStmt,
+    ) -> None:
+        """Visit a CreateFunctionStmt."""
+        is_security_definer = False
+        has_search_path = False
+        last_element_in_search_path = None
+
+        for option in typing.cast(tuple[ast.DefElem], node.options):
+            name = option.defname.upper()
+            if name == "SECURITY" and option.arg.boolval:
+                is_security_definer = True
+            elif name == "SET" and option.arg.name == "search_path":
+                has_search_path = True
+                last_element_in_search_path = option.arg.args[-1].val.sval
+
+        if (
+            is_security_definer
+            and has_search_path
+            and last_element_in_search_path != "pg_temp"
+        ):
+            self.violations.add(
+                linter.Violation(
+                    rule_code=self.code,
+                    rule_name=self.name,
+                    rule_category=self.category,
+                    line_number=self.line_number,
+                    column_offset=self.column_offset,
+                    line=self.line,
+                    statement_location=self.statement_location,
+                    description="Security definer function without pg_temp as the last element in the search path",  # noqa: E501
+                    is_auto_fixable=self.is_auto_fixable,
+                    is_fix_enabled=self.is_fix_enabled,
+                    help="Set pg_temp as the last element in the search path",
+                ),
+            )
+
+            self._fix(node)
+
+    def _fix(self, node: ast.CreateFunctionStmt) -> None:
+        """Fix violation."""
+        for option in typing.cast(tuple[ast.DefElem], node.options):
+            if option.defname.upper() == "SET" and option.arg.name == "search_path":
+                non_temp_schemas = tuple(
+                    schema
+                    for schema in typing.cast(tuple[ast.A_Const], option.arg.args)
+                    if schema.val.sval != "pg_temp"
+                )
+                option.arg.args = (*non_temp_schemas, ast.String(sval="pg_temp"))

--- a/src/pgrubic/rules/security/ST005.py
+++ b/src/pgrubic/rules/security/ST005.py
@@ -50,8 +50,8 @@ class SecurityDefinerFunctionNonTempSchema(linter.BaseChecker):
             if (
                 name == enums.FunctionOption.SET
                 and isinstance(option.arg, ast.VariableSetStmt)
-                and option.arg.kind == pglast_enums.VariableSetKind.VAR_SET_VALUE
                 and option.arg.name == "search_path"
+                and option.arg.kind == pglast_enums.VariableSetKind.VAR_SET_VALUE
             ):
                 has_explicit_search_path = True
                 if any(

--- a/src/pgrubic/rules/security/ST005.py
+++ b/src/pgrubic/rules/security/ST005.py
@@ -54,7 +54,7 @@ class SecurityDefinerFunctionNonTempSchema(linter.BaseChecker):
                 and option.arg.kind == pglast_enums.VariableSetKind.VAR_SET_VALUE
             ):
                 has_explicit_search_path = True
-                if any(
+                if option.arg.args and any(
                     schema.val.sval != "pg_temp"
                     for schema in typing.cast(tuple[ast.A_Const], option.arg.args)
                 ):

--- a/src/pgrubic/rules/security/ST005.py
+++ b/src/pgrubic/rules/security/ST005.py
@@ -50,8 +50,8 @@ class SecurityDefinerFunctionNonTempSchema(linter.BaseChecker):
             if (
                 name == enums.FunctionOption.SET
                 and isinstance(option.arg, ast.VariableSetStmt)
-                and option.arg.name == "search_path"
                 and option.arg.kind == pglast_enums.VariableSetKind.VAR_SET_VALUE
+                and option.arg.name == "search_path"
             ):
                 has_explicit_search_path = True
                 if any(

--- a/src/pgrubic/rules/security/ST005.py
+++ b/src/pgrubic/rules/security/ST005.py
@@ -84,6 +84,7 @@ class SecurityDefinerFunctionNonTempSchema(linter.BaseChecker):
         for option in typing.cast(tuple[ast.DefElem], node.options):
             if (
                 option.defname == enums.FunctionOption.SET
+                and isinstance(option.arg, ast.VariableSetStmt)
                 and option.arg.name == "search_path"
             ):
                 option.arg.args = (

--- a/src/pgrubic/rules/security/ST005.py
+++ b/src/pgrubic/rules/security/ST005.py
@@ -54,6 +54,7 @@ class SecurityDefinerFunctionNonTempSchema(linter.BaseChecker):
                 and option.arg.kind == pglast_enums.VariableSetKind.VAR_SET_VALUE
             ):
                 has_explicit_search_path = True
+
                 if option.arg.args and any(
                     schema.val.sval != "pg_temp"
                     for schema in typing.cast(tuple[ast.A_Const], option.arg.args)

--- a/tests/fixtures/rules/security/ST003.yml
+++ b/tests/fixtures/rules/security/ST003.yml
@@ -1,0 +1,35 @@
+---
+rule: ST003
+
+test_fail_security_definer_function_without_search_path:
+  sql_fail: |
+    CREATE FUNCTION security_definer()
+    RETURNS TEXT LANGUAGE SQL SECURITY DEFINER AS $$ SELECT 1; $$;
+
+test_pass_security_definer_function_with_search_path:
+  sql_pass: |
+    CREATE FUNCTION security_definer()
+    RETURNS TEXT LANGUAGE SQL SECURITY DEFINER
+    SET search_path = admin, pg_temp AS $$ SELECT 1; $$;
+
+test_pass_security_invoker_function_without_search_path:
+  sql_pass: |
+    CREATE FUNCTION security_invoker()
+    RETURNS TEXT LANGUAGE SQL SECURITY INVOKER AS $$ SELECT 1; $$;
+
+test_pass_security_invoker_function_with_search_path:
+  sql_pass: |
+    CREATE FUNCTION security_invoker()
+    RETURNS TEXT LANGUAGE SQL SECURITY INVOKER
+    SET search_path = admin, pg_temp AS $$ SELECT 1; $$;
+
+test_pass_security_default_function_without_search_path:
+  sql_pass: |
+    CREATE FUNCTION security_default()
+    RETURNS TEXT LANGUAGE SQL AS $$ SELECT 1; $$;
+
+test_pass_security_default_function_with_search_path:
+  sql_pass: |
+    CREATE FUNCTION security_default()
+    RETURNS TEXT LANGUAGE SQL
+    SET search_path = admin, pg_temp AS $$ SELECT 1; $$;

--- a/tests/fixtures/rules/security/ST003.yml
+++ b/tests/fixtures/rules/security/ST003.yml
@@ -3,14 +3,59 @@ rule: ST003
 
 test_fail_security_definer_function_without_search_path:
   sql_fail: |
-    CREATE FUNCTION security_definer()
+    CREATE OR REPLACE FUNCTION security_definer()
     RETURNS TEXT LANGUAGE SQL SECURITY DEFINER AS $$ SELECT 1; $$;
+  sql_fix: |
+    CREATE OR REPLACE FUNCTION security_definer ()
+    RETURNS text
+    LANGUAGE SQL
+    SECURITY DEFINER
+    SET search_path TO '', 'pg_temp'
+    AS $BODY$
+        SELECT 1;
+    $BODY$;
+
+test_fail_security_definer_function_with_default_search_path:
+  sql_fail: |
+    CREATE OR REPLACE FUNCTION security_definer()
+    RETURNS TEXT LANGUAGE SQL SECURITY DEFINER
+    SET search_path TO DEFAULT AS $$ SELECT 1; $$;
+  sql_fix: |
+    CREATE OR REPLACE FUNCTION security_definer ()
+    RETURNS text
+    LANGUAGE SQL
+    SECURITY DEFINER
+    SET search_path TO '', 'pg_temp'
+    AS $BODY$
+        SELECT 1;
+    $BODY$;
+
+test_fail_security_definer_function_with_current_search_path:
+  sql_fail: |
+    CREATE OR REPLACE FUNCTION security_definer()
+    RETURNS TEXT LANGUAGE SQL SECURITY DEFINER
+    SET search_path FROM CURRENT AS $$ SELECT 1; $$;
+  sql_fix: |
+    CREATE OR REPLACE FUNCTION security_definer ()
+    RETURNS text
+    LANGUAGE SQL
+    SECURITY DEFINER
+    SET search_path TO '', 'pg_temp'
+    AS $BODY$
+        SELECT 1;
+    $BODY$;
 
 test_pass_security_definer_function_with_search_path:
   sql_pass: |
     CREATE FUNCTION security_definer()
     RETURNS TEXT LANGUAGE SQL SECURITY DEFINER
-    SET search_path = admin, pg_temp AS $$ SELECT 1; $$;
+    SET search_path = pg_temp AS $$ SELECT 1; $$;
+
+test_pass_security_definer_function_with_empty_search_path:
+  sql_pass: |
+    CREATE FUNCTION security_definer()
+    RETURNS TEXT LANGUAGE SQL SECURITY DEFINER
+    SET search_path = '' AS $$ SELECT 1; $$;
 
 test_pass_security_invoker_function_without_search_path:
   sql_pass: |
@@ -21,7 +66,7 @@ test_pass_security_invoker_function_with_search_path:
   sql_pass: |
     CREATE FUNCTION security_invoker()
     RETURNS TEXT LANGUAGE SQL SECURITY INVOKER
-    SET search_path = admin, pg_temp AS $$ SELECT 1; $$;
+    SET search_path = admin AS $$ SELECT 1; $$;
 
 test_pass_security_default_function_without_search_path:
   sql_pass: |

--- a/tests/fixtures/rules/security/ST004.yml
+++ b/tests/fixtures/rules/security/ST004.yml
@@ -1,0 +1,48 @@
+---
+rule: ST004
+
+test_fail_security_definer_function_without_pg_temp_last_element_in_search_path:
+  sql_fail: |
+    CREATE OR REPLACE FUNCTION security_definer()
+    RETURNS TEXT LANGUAGE SQL SECURITY DEFINER SET TIME ZONE 'Europe/Rome'
+    SET search_path = admin AS $$ SELECT 1; $$;
+  sql_fix: |
+    CREATE OR REPLACE FUNCTION security_definer ()
+    RETURNS text
+    LANGUAGE SQL
+    SECURITY DEFINER
+    SET TIME ZONE 'Europe/Rome'
+    SET search_path TO 'admin'
+                     , 'pg_temp'
+    AS $BODY$
+        SELECT 1;
+    $BODY$;
+
+test_fail_security_definer_function_with_pg_temp_not_last_element_in_search_path:
+  sql_fail: |
+    CREATE OR REPLACE FUNCTION security_definer()
+    RETURNS TEXT LANGUAGE SQL SECURITY DEFINER SET TIME ZONE 'Europe/Rome'
+    SET search_path = pg_temp, admin AS $$ SELECT 1; $$;
+  sql_fix: |
+    CREATE OR REPLACE FUNCTION security_definer ()
+    RETURNS text
+    LANGUAGE SQL
+    SECURITY DEFINER
+    SET TIME ZONE 'Europe/Rome'
+    SET search_path TO 'admin'
+                     , 'pg_temp'
+    AS $BODY$
+        SELECT 1;
+    $BODY$;
+
+test_pass_security_definer_function_with_pg_temp_last_element_in_search_path:
+  sql_pass: |
+    CREATE FUNCTION security_definer()
+    RETURNS TEXT LANGUAGE SQL SECURITY DEFINER SET TIME ZONE 'Europe/Rome'
+    SET search_path = admin, pg_temp AS $$ SELECT 1; $$;
+
+test_pass_security_definer_function_without_search_path:
+  sql_pass: |
+    CREATE FUNCTION security_definer()
+    RETURNS TEXT LANGUAGE SQL SECURITY DEFINER
+    SET TIME ZONE 'Europe/Rome' AS $$ SELECT 1; $$;

--- a/tests/fixtures/rules/security/ST005.yml
+++ b/tests/fixtures/rules/security/ST005.yml
@@ -1,39 +1,23 @@
 ---
-rule: ST004
+rule: ST005
 
-test_fail_security_definer_function_without_pg_temp_last_element_in_search_path:
+test_fail_security_definer_function_no_non_temp_in_search_path:
   sql_fail: |
     CREATE OR REPLACE FUNCTION security_definer()
     RETURNS TEXT LANGUAGE SQL SECURITY DEFINER SET TIME ZONE 'Europe/Rome'
-    SET search_path = admin AS $$ SELECT 1; $$;
+    SET search_path = pg_temp AS $$ SELECT 1; $$;
   sql_fix: |
     CREATE OR REPLACE FUNCTION security_definer ()
     RETURNS text
     LANGUAGE SQL
     SECURITY DEFINER
     SET TIME ZONE 'Europe/Rome'
-    SET search_path TO 'admin', 'pg_temp'
+    SET search_path TO '', 'pg_temp'
     AS $BODY$
         SELECT 1;
     $BODY$;
 
-test_fail_security_definer_function_with_pg_temp_not_last_element_in_search_path:
-  sql_fail: |
-    CREATE OR REPLACE FUNCTION security_definer()
-    RETURNS TEXT LANGUAGE SQL SECURITY DEFINER SET TIME ZONE 'Europe/Rome'
-    SET search_path = pg_temp, admin AS $$ SELECT 1; $$;
-  sql_fix: |
-    CREATE OR REPLACE FUNCTION security_definer ()
-    RETURNS text
-    LANGUAGE SQL
-    SECURITY DEFINER
-    SET TIME ZONE 'Europe/Rome'
-    SET search_path TO 'admin', 'pg_temp'
-    AS $BODY$
-        SELECT 1;
-    $BODY$;
-
-test_pass_security_definer_function_with_pg_temp_last_element_in_search_path:
+test_pass_security_definer_function_with_non_temp_in_search_path:
   sql_pass: |
     CREATE FUNCTION security_definer()
     RETURNS TEXT LANGUAGE SQL SECURITY DEFINER SET TIME ZONE 'Europe/Rome'
@@ -56,9 +40,3 @@ test_pass_security_definer_function_with_default_search_path:
     CREATE FUNCTION security_definer()
     RETURNS TEXT LANGUAGE SQL SECURITY DEFINER
     SET TIME ZONE 'Europe/Rome' SET search_path TO DEFAULT AS $$ SELECT 1; $$;
-
-test_pass_security_definer_function_with_pg_temp_only_in_search_path:
-  sql_pass: |
-    CREATE FUNCTION security_definer()
-    RETURNS TEXT LANGUAGE SQL SECURITY DEFINER SET TIME ZONE 'Europe/Rome'
-    SET search_path = pg_temp AS $$ SELECT 1; $$;

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -5,7 +5,7 @@ from pgrubic import core
 
 def test_load_rules(linter: core.Linter) -> None:
     """Test loading rules."""
-    expected_number_of_rules = 108
+    expected_number_of_rules = 110
 
     rules = core.load_rules(config=linter.config)
 

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -5,7 +5,7 @@ from pgrubic import core
 
 def test_load_rules(linter: core.Linter) -> None:
     """Test loading rules."""
-    expected_number_of_rules = 110
+    expected_number_of_rules = 111
 
     rules = core.load_rules(config=linter.config)
 

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -57,6 +57,8 @@ def test_rules(
             source_code=parsed_test_case.sql_fail,
         )
 
+        assert len(linting_result.errors) == 0, "Test failed: Errors found in test case"
+
         assert any(
             violation.rule_code == rule for violation in linting_result.violations
         ), f"Test failed: No violations found for rule: `{rule}` in `{test_id}`"
@@ -76,6 +78,8 @@ def test_rules(
             source_file=f"{parsed_test_case.rule}.sql",
             source_code=parsed_test_case.sql_pass,
         )
+
+        assert len(linting_result.errors) == 0, "Test failed: Errors found in test case"
 
         assert not any(
             violation.rule_code == rule for violation in linting_result.violations


### PR DESCRIPTION
## Pull Request Overview

This pull request adds three new security rules (ST003, ST004, ST005) for PostgreSQL security definer functions to enforce proper search path configurations and prevent security vulnerabilities.

- Adds rules to validate search path configurations in security definer functions
- Includes comprehensive test fixtures for all three new rules  
- Updates rule count and documentation to reflect the new additions