### PR TITLE
chore: add issue and pull request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,102 @@
+---
+# yamllint disable rule:line-length
+name: Bug report
+description: Report a problem with the linter or formatter
+title: "[Bug] <short description>"
+labels: [bug]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug! Please provide as much detail as possible to help us reproduce and fix it.
+
+  - type: checkboxes
+    attributes:
+      label: Search before submitting
+      description: >
+        Before opening a new issue, please search the existing [issues](https://github.com/bolajiwahab/pgrubic/issues)
+        to see if your question or problem has already been reported.
+      options:
+        - label: >
+            I have searched the [issues](https://github.com/bolajiwahab/pgrubic/issues) and confirmed that no similar issue exists.
+          required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What happened, and what did you expect to happen instead?
+      placeholder: "When running on XYZ.sql, the linter flagged ..., but it should have ..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: sql
+    attributes:
+      label: Minimal SQL to reproduce
+      description: Provide a small, self-contained SQL snippet that triggers the bug.
+      placeholder: |
+        ```sql
+        CREATE TABLE test (id INT PRIMARY KEY);
+        ```
+      render: shell
+    validations:
+      required: true
+
+  - type: textarea
+    id: output
+    attributes:
+      label: Actual vs Expected Output
+      description: Show what the **pgrubic** produced vs what you expected.
+      placeholder: |
+        **Actual:**
+        ...
+
+        **Expected:**
+        ...
+
+  - type: textarea
+    attributes:
+      label: Option
+      description: What option did you use to run pgrubic (lint/format)?
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: Run `pgrubic --version` and paste the output.
+      placeholder: "0.7.0"
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: OS, PostgreSQL version, Python version.
+      placeholder: "Ubuntu 22.04, PostgreSQL 15, Python 3.12"
+
+  - type: textarea
+    attributes:
+      label: Configuration
+      description: Include your **pgrubic** configuration (`pgrubic.toml`) here
+    validations:
+      required: true
+
+  - type: checkboxes
+    attributes:
+      label: Are you willing to work on and submit a PR to address the issue?
+      description: >
+        Submitting a pull request is completely optional, but we welcome and guide new contributors.
+        If you have an idea for a fix and some understanding of how to implement it, we’d love your help.
+        **pgrubic** is a community-driven project, and your contributions make a big difference!
+      options:
+        - label: Yes, I am willing to submit a PR :)
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs or Screenshots
+      description: Any additional logs, stack traces, or screenshots that might help.

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -22,11 +22,23 @@ body:
           required: true
 
   - type: textarea
-    id: description
+    id: actual
     attributes:
-      label: Description
-      description: What happened, and what did you expect to happen instead?
-      placeholder: "When running on XYZ.sql, the linter flagged ..., but it should have ..."
+      label: Actual Behaviour
+      description: Describe what actually happened.
+      placeholder: >
+        Explain the context and issue you observed (without SQL).
+        Include any error messages or unexpected behaviour.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behaviour
+      description: Describe what you expected to happen.
+      placeholder: >
+        Explain the correct output or behaviour you were expecting.
     validations:
       required: true
 
@@ -55,7 +67,7 @@ body:
         **Expected:**
         ...
 
-  - type: textarea
+  - type: input
     attributes:
       label: Option
       description: What option did you use to run pgrubic (lint/format)?
@@ -77,6 +89,8 @@ body:
       label: Environment
       description: OS, PostgreSQL version, Python version.
       placeholder: "Ubuntu 22.04, PostgreSQL 15, Python 3.12"
+    validations:
+      required: true
 
   - type: textarea
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -27,7 +27,7 @@ body:
       label: Actual Behaviour
       description: Describe what actually happened.
       placeholder: >
-        Explain the context and issue you observed (without SQL).
+        Provide the context and issue you observed (without SQL).
         Include any error messages or unexpected behaviour.
     validations:
       required: true
@@ -38,7 +38,7 @@ body:
       label: Expected Behaviour
       description: Describe what you expected to happen.
       placeholder: >
-        Explain the correct output or behaviour you were expecting.
+        Provide the correct output or behaviour you were expecting.
     validations:
       required: true
 
@@ -48,24 +48,10 @@ body:
       label: Minimal SQL to reproduce
       description: Provide a small, self-contained SQL snippet that triggers the bug.
       placeholder: |
-        ```sql
         CREATE TABLE test (id INT PRIMARY KEY);
-        ```
-      render: shell
+      render: sql
     validations:
       required: true
-
-  - type: textarea
-    id: output
-    attributes:
-      label: Actual vs Expected Output
-      description: Show what the **pgrubic** produced vs what you expected.
-      placeholder: |
-        **Actual:**
-        ...
-
-        **Expected:**
-        ...
 
   - type: input
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -100,3 +100,7 @@ body:
     attributes:
       label: Logs or Screenshots
       description: Any additional logs, stack traces, or screenshots that might help.
+
+  - type: markdown
+    attributes:
+      value: "Thanks for completing the form!"

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+---
+# yamllint disable rule:line-length
+blank_issues_enabled: false
+
+contact_links:
+  - name: 💬 Questions & Discussions
+    url: https://github.com/bolajiwahab/pgrubic/discussions
+    about: Please ask questions, ideas, or general discussions here instead of opening an issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -8,7 +8,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Use this feature request template to suggest new features or functionality for pgrubic.
+        Use this feature request template to suggest new features or functionality for **pgrubic**.
 
   - type: checkboxes
     attributes:
@@ -55,4 +55,4 @@ body:
 
   - type: markdown
     attributes:
-      value: "Thanks for completing our form!"
+      value: "Thanks for completing the form!"

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,58 @@
+---
+# yamllint disable rule:line-length
+name: Feature request
+description: Suggest a new lint rule, formatter option, or improvement
+title: "[Feature] <short description>"
+labels: [enhancement]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this feature request template to suggest new features or functionality for pgrubic.
+
+  - type: checkboxes
+    attributes:
+      label: Search before submitting
+      description: >
+        Before opening a new issue, please search the existing [issues](https://github.com/bolajiwahab/pgrubic/issues)
+        to see if your question or problem has already been reported.
+      options:
+        - label: >
+            I have searched the [issues](https://github.com/bolajiwahab/pgrubic/issues) and confirmed that no similar issue exists.
+          required: true
+
+  - type: textarea
+    attributes:
+      label: Description
+      description: A short description of the feature
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Use case
+      description: What do you want to happen?
+      placeholder: >
+        Instead of focusing on how the feature might be implemented, please describe the problem you want to solve or
+        the outcome you are aiming for.
+
+  - type: input
+    attributes:
+      label: Option
+      description: Which option does this feature relates to (lint/format)?
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Workarounds
+      description: Did you consider other workarounds?
+
+  - type: textarea
+    attributes:
+      label: Implementation Suggestion
+      description: How would you implement this feature?
+
+  - type: markdown
+    attributes:
+      value: "Thanks for completing our form!"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,37 @@
+## Background and Motivation
+<!-- Why is this change needed? What problem does it solve? -->
+
+## Summary of Changes
+<!-- High-level overview of what was changed. -->
+
+## Type of change
+<!-- Select the type of change. -->
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds new functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Housekeeping (change that does not affect functionality)
+
+## SQL Examples (if applicable)
+<!-- Provide sample SQL to show before/after behavior of the linter/formatter. -->
+
+```sql
+-- Before
+...
+
+-- After
+...
+```
+
+## Checklist
+<!-- Checklist before requesting a review -->
+- [ ] I have read and followed the [contributing guidelines](https://github.com/bolajiwahab/pgrubic/blob/main/docs/docs/contributing.md)
+- [ ] I have checked that there are no other open [Pull Requests](https://github.com/bolajiwahab/pgrubic/pulls) for the same update/change
+- [ ] I have performed a self-review of my code
+- [ ] I have added/updated tests (positive + negative cases)
+- [ ] I have updated documentation (if applicable)
+
+## Closes / Fixes
+<!-- Link issues using keywords: Closes #123, Fixes #456 -->
+
+## Additional information
+<!-- Provide any additional information that might be helpful to the reviewer in reviewing this pull request -->


### PR DESCRIPTION
## Pull Request Overview

This PR adds GitHub issue and pull request templates to standardize the submission process for bug reports, feature requests, and pull requests. The templates provide structured forms with required fields to improve issue quality and maintainability.

- Adds a comprehensive pull request template with sections for background, changes, and checklists
- Creates issue templates for bug reports and feature requests with detailed structured forms
- Configures issue template settings to disable blank issues and provide discussion links