### PR TITLE
fix(linter): yoda condition operator fixes

### DIFF
--- a/src/pgrubic/__init__.py
+++ b/src/pgrubic/__init__.py
@@ -44,7 +44,7 @@ FORMATTERS_BASE_MODULE: typing.Final[str] = f"{PACKAGE_NAME}/formatters/"
 
 
 def get_fully_qualified_name(node: tuple[ast.Node]) -> str:
-    """Get fully qualified type name.
+    """Get fully qualified name.
 
     Parameters:
     ----------
@@ -54,7 +54,7 @@ def get_fully_qualified_name(node: tuple[ast.Node]) -> str:
     Returns:
     -------
     str
-        Fully qualified type name.
+        Fully qualified name.
 
     """
     if isinstance(node, ast.String):

--- a/src/pgrubic/rules/general/GN027.py
+++ b/src/pgrubic/rules/general/GN027.py
@@ -59,8 +59,23 @@ class YodaCondition(linter.BaseChecker):
 
     def _fix(self, node: ast.A_Expr) -> None:
         """Fix violation."""
+        operator_replacements = {
+            ">": "<",
+            "<": ">",
+            ">=": "<=",
+            "<=": ">=",
+            "=": "=",
+            "!=": "!=",
+            "<>": "<>",
+        }
+
+        name = node.name
+        # Adjust the operator accordingly
+        name[-1].sval = operator_replacements[name[-1].sval]
+
         lexpr = node.lexpr
         rexpr = node.rexpr
 
         node.lexpr = rexpr
         node.rexpr = lexpr
+        node.name = name

--- a/src/pgrubic/rules/general/GN031.py
+++ b/src/pgrubic/rules/general/GN031.py
@@ -1,4 +1,4 @@
-"""Checker for yoda conditions."""
+"""Checker for stringified NULL."""
 
 from pglast import ast, enums, visitors
 

--- a/tests/fixtures/rules/general/GN027.yml
+++ b/tests/fixtures/rules/general/GN027.yml
@@ -1,13 +1,101 @@
 ---
 rule: GN027
 
-test_fail_yoda_condition:
+test_fail_yoda_condition_equal_to:
   sql_fail: |
     SELECT * FROM measurement WHERE 10 = city_id;
   sql_fix: |
     SELECT *
       FROM measurement
      WHERE city_id = 10;
+
+test_fail_yoda_condition_not_equal_to:
+  sql_fail: |
+    SELECT * FROM measurement WHERE 10 != city_id;
+  sql_fix: |
+    SELECT *
+      FROM measurement
+     WHERE city_id <> 10;
+
+test_fail_yoda_condition_greater_than:
+  sql_fail: |
+    SELECT * FROM measurement WHERE 10 > city_id;
+  sql_fix: |
+    SELECT *
+      FROM measurement
+     WHERE city_id < 10;
+
+test_fail_yoda_condition_less_than:
+  sql_fail: |
+    SELECT * FROM measurement WHERE 10 < city_id;
+  sql_fix: |
+    SELECT *
+      FROM measurement
+     WHERE city_id > 10;
+
+test_fail_yoda_condition_greater_than_or_equal_to:
+  sql_fail: |
+    SELECT * FROM measurement WHERE 10 >= city_id;
+  sql_fix: |
+    SELECT *
+      FROM measurement
+     WHERE city_id <= 10;
+
+test_fail_yoda_condition_less_than_or_equal_to:
+  sql_fail: |
+    SELECT * FROM measurement WHERE 10 <= city_id;
+  sql_fix: |
+    SELECT *
+      FROM measurement
+     WHERE city_id >= 10;
+
+test_fail_yoda_condition_equal_to_qualified_operator:
+  sql_fail: |
+    SELECT * FROM measurement WHERE 10 OPERATOR(pg_catalog.=) city_id;
+  sql_fix: |
+    SELECT *
+      FROM measurement
+     WHERE city_id OPERATOR(pg_catalog.=) 10;
+
+test_fail_yoda_condition_not_equal_to_qualified_operator:
+  sql_fail: |
+    SELECT * FROM measurement WHERE 10 OPERATOR(pg_catalog.!=) city_id;
+  sql_fix: |
+    SELECT *
+      FROM measurement
+     WHERE city_id OPERATOR(pg_catalog.<>) 10;
+
+test_fail_yoda_condition_greater_than_qualified_operator:
+  sql_fail: |
+    SELECT * FROM measurement WHERE 10 OPERATOR(pg_catalog.>) city_id;
+  sql_fix: |
+    SELECT *
+      FROM measurement
+     WHERE city_id OPERATOR(pg_catalog.<) 10;
+
+test_fail_yoda_condition_less_than_qualified_operator:
+  sql_fail: |
+    SELECT * FROM measurement WHERE 10 OPERATOR(pg_catalog.<) city_id;
+  sql_fix: |
+    SELECT *
+      FROM measurement
+     WHERE city_id OPERATOR(pg_catalog.>) 10;
+
+test_fail_yoda_condition_greater_than_or_equal_to_qualified_operator:
+  sql_fail: |
+    SELECT * FROM measurement WHERE 10 OPERATOR(pg_catalog.>=) city_id;
+  sql_fix: |
+    SELECT *
+      FROM measurement
+     WHERE city_id OPERATOR(pg_catalog.<=) 10;
+
+test_fail_yoda_condition_less_than_or_equal_to_qualified_operator:
+  sql_fail: |
+    SELECT * FROM measurement WHERE 10 OPERATOR(pg_catalog.<=) city_id;
+  sql_fix: |
+    SELECT *
+      FROM measurement
+     WHERE city_id OPERATOR(pg_catalog.>=) 10;
 
 test_pass_yoda_condition_with_constants:
   sql_pass: |


### PR DESCRIPTION
## Background and Motivation
<!-- Why is this change needed? What problem does it solve? -->

Yoda conditions https://en.wikipedia.org/wiki/Yoda_conditions are currently flagged by `GN027` with automatic fixes available. But the fixes were not taking into account the operator especially when the operator is not `=` and thus need a rewrite.

## Summary of Changes
<!-- High-level overview of what was changed. -->

Track the operator and rewrite it accordingly in fixes.

## Type of change
<!-- Select the type of change. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Housekeeping (change that does not affect functionality)

## SQL Examples (if applicable)
<!-- Provide sample SQL to show before/after behavior of the linter/formatter. -->

```sql
-- Before
...

-- After
...
```

## Checklist
<!-- Checklist before requesting a review -->
- [ ] I have read and followed the [contributing guidelines](https://github.com/bolajiwahab/pgrubic/blob/main/docs/docs/contributing.md)
- [ ] I have checked that there are no other open [Pull Requests](https://github.com/bolajiwahab/pgrubic/pulls) for the same update/change
- [ ] I have performed a self-review of my code
- [ ] I have added/updated tests (positive + negative cases)
- [ ] I have updated documentation (if applicable)

## Closes / Fixes
<!-- Link issues using keywords: Closes #123, Fixes #456 -->

## Additional information
<!-- Provide any additional information that might be helpful to the reviewer in reviewing this pull request -->
