### PR TITLE
docs: add US031 to list of rules

### DIFF
--- a/docs/docs/rules.md
+++ b/docs/docs/rules.md
@@ -163,4 +163,4 @@ There are **100+** rules and all rules are enabled by default. Rule are divided 
 | US028 | [non-concurrent-refresh-materialized-view](rules/unsafe/non-concurrent-refresh-materialized-view.md)                               | :white_check_mark: | :white_check_mark:                                                                                                                                                            |
 | US029 | [truncate-table](rules/unsafe/truncate-table.md)                                                                                   | :white_check_mark: | :x:       |
 | US030 | [mismatch-column-in-data-type-change](rules/unsafe/mismatch-column-in-data-type-change.md)                                         | :white_check_mark: | :x:       |
-| US031 | [new-column-with-volatile-default](rules/unsafe/new-column-with-volatile-default.md)                                         | :white_check_mark: | :x:       |
+| US031 | [new-column-with-volatile-default](rules/unsafe/new-column-with-volatile-default.md)                                               | :white_check_mark: | :x:       |


### PR DESCRIPTION
## Background and Motivation
<!-- Why is this change needed? What problem does it solve? -->
Add US031 to the list of rules in the **rules** page.
## Summary of Changes
<!-- High-level overview of what was changed. -->
This PR adds documentation for a new unsafe rule US031 related to new columns with volatile defaults to the rules list in the documentation.

- Added US031 rule entry to the rules table
- Rule addresses new columns with volatile default values
- Follows existing pattern for unsafe rule documentation

## Type of change
<!-- Select the type of change. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Housekeeping (change that does not affect functionality)

## SQL Examples (if applicable)
<!-- Provide sample SQL to show before/after behavior of the linter/formatter. -->

```sql
-- Before
...

-- After
...
```

## Checklist
<!-- Checklist before requesting a review -->
- [x] I have read and followed the [contributing guidelines](https://github.com/bolajiwahab/pgrubic/blob/main/docs/docs/contributing.md)
- [x] I have checked that there are no other open [Pull Requests](https://github.com/bolajiwahab/pgrubic/pulls) for the same update/change
- [x] I have performed a self-review of my code
- [ ] I have added/updated tests (positive + negative cases)
- [x] I have updated documentation (if applicable)

## Closes / Fixes
<!-- Link issues using keywords: Closes #123, Fixes #456 -->

## Additional information
<!-- Provide any additional information that might be helpful to the reviewer in reviewing this pull request -->
