### PR TITLE
fix(formatter): handle new lines during errors

### DIFF
--- a/src/pgrubic/core/formatter.py
+++ b/src/pgrubic/core/formatter.py
@@ -106,7 +106,7 @@ class Formatter:
                             hint=f"""Make sure the statement is valid PostgreSQL statement. If it is, please report this issue at {ISSUES_URL}{noqa.NEW_LINE}""",  # noqa: E501
                         ),
                     )
-                    formatted_statements.append(statement.text)
+                    formatted_statements.append(statement.text.strip(noqa.NEW_LINE))
 
                 except RecursionError as error:  # pragma: no cover
                     _errors.add(
@@ -120,7 +120,7 @@ class Formatter:
                             hint="Maximum format depth exceeded, reduce deeply nested queries",  # noqa: E501
                         ),
                     )
-                    formatted_statements.append(statement.text)
+                    formatted_statements.append(statement.text.strip(noqa.NEW_LINE))
 
             return (
                 noqa.NEW_LINE + (noqa.NEW_LINE * config.format.lines_between_statements)

--- a/src/pgrubic/core/linter.py
+++ b/src/pgrubic/core/linter.py
@@ -542,9 +542,6 @@ class Linter:
 
             BaseChecker.lint_ignores = lint_ignores
 
-            # Reset the applied fixes for each statement
-            BaseChecker.applied_fixes = []
-
             BaseChecker.root_statement = statement.text
             BaseChecker.statement_location = statement.start_location
 


### PR DESCRIPTION
## Background and Motivation
<!-- Why is this change needed? What problem does it solve? -->
Handle new lines during errors while formatting.
## Summary of Changes
<!-- High-level overview of what was changed. -->
This PR fixes how the formatter handles newlines during error scenarios. When formatting fails due to validation or recursion errors, the original statement text is preserved but with trailing newlines stripped to maintain consistent output formatting.

- Removes the reset of applied fixes in the linter for each statement
- Strips trailing newlines from statement text when formatting errors occur
## Type of change
<!-- Select the type of change. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Housekeeping (change that does not affect functionality)

## SQL Examples (if applicable)
<!-- Provide sample SQL to show before/after behavior of the linter/formatter. -->

```sql
-- Before
TRUNCATE TABLE public.t1;


select a from;
-- After
TRUNCATE TABLE public.t1;

select a from;

```

## Checklist
<!-- Checklist before requesting a review -->
- [x] I have read and followed the [contributing guidelines](https://github.com/bolajiwahab/pgrubic/blob/main/docs/docs/contributing.md)
- [x] I have checked that there are no other open [Pull Requests](https://github.com/bolajiwahab/pgrubic/pulls) for the same update/change
- [x] I have performed a self-review of my code
- [ ] I have added/updated tests (positive + negative cases)
- [ ] I have updated documentation (if applicable)

## Closes / Fixes
<!-- Link issues using keywords: Closes #123, Fixes #456 -->

## Additional information
<!-- Provide any additional information that might be helpful to the reviewer in reviewing this pull request -->
