### PR TITLE
feat!: make config dependency of rules explicit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ version_scheme = "semver2"
 version_provider = "pep621"
 update_changelog_on_bump = true
 bump_message = "chore(bump): version $current_version → $new_version"
+breaking_change_exclamation_in_title = true
 version_files = [
     "README.md:rev",
     "docs/docs/tutorial.md:rev",

--- a/src/pgrubic/__main__.py
+++ b/src/pgrubic/__main__.py
@@ -126,7 +126,7 @@ def lint(  # noqa: C901, PLR0912, PLR0913, PLR0915
     rules: set[type[core.BaseChecker]] = core.load_rules(config=config)
 
     for rule in rules:
-        linter.checkers.add(rule())
+        linter.checkers.add(rule(config=config))
 
     # Use the current working directory if no sources are specified
     if not sources:

--- a/src/pgrubic/core/linter.py
+++ b/src/pgrubic/core/linter.py
@@ -197,7 +197,6 @@ class BaseChecker(visitors.Visitor, metaclass=CheckerMeta):
     is_auto_fixable: bool = False
 
     # Attributes shared among all subclasses
-    config: config.Config
     lint_ignores: list[noqa.NoQaDirective]
     source_file: str
     source_code: str
@@ -215,9 +214,10 @@ class BaseChecker(visitors.Visitor, metaclass=CheckerMeta):
     statement_fixes: FixCounter
     file_fixes: FixCounter
 
-    def __init__(self) -> None:
+    def __init__(self, *, config: config.Config) -> None:
         """Initialize variables."""
         self.violations: set[Violation] = set()
+        self.config = config
 
     def __init_subclass__(cls, **kwargs: typing.Any) -> None:
         """Set code, name and category attributes for subclasses."""
@@ -522,7 +522,6 @@ class Linter:
 
         BaseChecker.source_code = source_code
         BaseChecker.source_file = source_file
-        BaseChecker.config = self.config
 
         BaseChecker.file_fixes = FixCounter()
         BaseChecker.statement_fixes = FixCounter()
@@ -549,8 +548,6 @@ class Linter:
             lint_ignores.extend(statement_lint_ignores)
 
             BaseChecker.lint_ignores = lint_ignores
-            BaseChecker.root_statement = statement.text
-            BaseChecker.statement_location = statement.start_location
 
             try:
                 parse_tree: tuple[ast.RawStmt, ...] = parser.parse_sql(statement.text)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,7 +22,7 @@ def linter() -> core.Linter:
     linter = core.Linter(config=config, formatters=core.load_formatters)
 
     for rule in rules:
-        linter.checkers.add(rule())
+        linter.checkers.add(rule(config=config))
 
     return linter
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,8 +15,6 @@ def linter() -> core.Linter:
     """Setup linter."""
     config: core.Config = core.parse_config()
 
-    core.BaseChecker.config = config
-
     rules: set[type[core.BaseChecker]] = core.load_rules(config=config)
 
     linter = core.Linter(config=config, formatters=core.load_formatters)


### PR DESCRIPTION
## Background and Motivation
<!-- Why is this change needed? What problem does it solve? -->
This PR makes lint rule configuration an explicit dependency by requiring `BaseChecker` instances to be constructed with a `config`, instead of relying on shared class-level state.

## Summary of Changes
<!-- High-level overview of what was changed. -->
- Update `BaseChecker` to require `config` in `__init__` and store it on the instance.
- Update rule instantiation call sites to pass `config` explicitly (`rule(config=config)`).
- Enable Commitizen’s `breaking_change_exclamation_in_title` to enforce `!` usage for breaking changes.

## Type of change
<!-- Select the type of change. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Housekeeping (change that does not affect functionality)

## SQL Examples (if applicable)
<!-- Provide sample SQL to show before/after behavior of the linter/formatter. -->

```sql
-- Before
...

-- After
...
```

## Checklist
<!-- Checklist before requesting a review -->
- [x] I have read and followed the [contributing guidelines](https://github.com/bolajiwahab/pgrubic/blob/main/docs/docs/contributing.md)
- [x] I have checked that there are no other open [Pull Requests](https://github.com/bolajiwahab/pgrubic/pulls) for the same update/change
- [x] I have performed a self-review of my code
- [ ] I have added/updated tests (positive + negative cases)
- [ ] I have updated documentation (if applicable)

## Closes / Fixes
<!-- Link issues using keywords: Closes #123, Fixes #456 -->

## Additional information
<!-- Provide any additional information that might be helpful to the reviewer in reviewing this pull request -->
