### PR TITLE
feat: flag self assigning column in updates

### DIFF
--- a/docs/docs/rules.md
+++ b/docs/docs/rules.md
@@ -1,6 +1,6 @@
 # Rules
 
-There are **114** rules, all enabled by default except deprecated
+There are **115** rules, all enabled by default except deprecated
 ones, which are not part of the active rule set.
 
 Rules are divided into 8 categories:
@@ -64,6 +64,7 @@ Rules are divided into 8 categories:
 | GN033 | [insert-without-target-columns](rules/general/insert-without-target-columns.md) | :white_check_mark: Stable | :x: |
 | GN034 | [typed-table](rules/general/typed-table.md) | :white_check_mark: Stable | :x: |
 | GN035 | [inline-sql-function-body-wrong-language](rules/general/inline-sql-function-body-wrong-language.md) | :white_check_mark: Stable | :white_check_mark: |
+| GN036 | [self-assigning-column](rules/general/self-assigning-column.md) | :white_check_mark: Stable | :x: |
 
 ## query (QY)
 

--- a/docs/docs/rules/general/self-assigning-column.md
+++ b/docs/docs/rules/general/self-assigning-column.md
@@ -1,0 +1,5 @@
+# self-assigning-column (GN036)
+
+Automatic fix is not available.
+
+::: pgrubic.rules.general.GN036.SelfAssigningColumn

--- a/src/pgrubic/__init__.py
+++ b/src/pgrubic/__init__.py
@@ -54,12 +54,12 @@ RULES_BASE_MODULE: typing.Final[str] = f"{PACKAGE_NAME}/rules/"
 FORMATTERS_BASE_MODULE: typing.Final[str] = f"{PACKAGE_NAME}/formatters/"
 
 
-def get_fully_qualified_name(node: tuple[ast.String] | ast.String) -> str:
+def get_fully_qualified_name(node: tuple[ast.String] | ast.String | ast.RangeVar) -> str:
     """Get fully qualified name.
 
     Parameters:
     ----------
-    node: tuple[ast.Node]
+    node: tuple[ast.String] | ast.String | ast.RangeVar
         Node to get fully qualified name for.
 
     Returns:

--- a/src/pgrubic/__init__.py
+++ b/src/pgrubic/__init__.py
@@ -71,7 +71,7 @@ def get_fully_qualified_name(node: tuple[ast.String] | ast.String | ast.RangeVar
     if isinstance(node, ast.String):
         return str(node.sval)
 
-    if isinstance(node, ast.RangeVar):
+    if isinstance(node, ast.RangeVar):  # pragma: no cover
         return ".".join(
             part
             for part in (node.catalogname, node.schemaname, node.relname)

--- a/src/pgrubic/__init__.py
+++ b/src/pgrubic/__init__.py
@@ -71,6 +71,13 @@ def get_fully_qualified_name(node: tuple[ast.String] | ast.String) -> str:
     if isinstance(node, ast.String):
         return str(node.sval)
 
+    if isinstance(node, ast.RangeVar):
+        return ".".join(
+            part
+            for part in (node.catalogname, node.schemaname, node.relname)
+            if part is not None
+        )
+
     return ".".join(n.sval for n in node if n.sval is not None)
 
 

--- a/src/pgrubic/rules/general/GN036.py
+++ b/src/pgrubic/rules/general/GN036.py
@@ -1,0 +1,54 @@
+"""Checker for self assigning column."""
+
+from pglast import ast, visitors
+
+from pgrubic import get_fully_qualified_name
+from pgrubic.core import linter
+
+
+class SelfAssigningColumn(linter.BaseChecker):
+    """## **What it does**
+    Checks for self assigning columns.
+
+    ## **Why not?**
+    Assigning a column to itself does not change its value but still causes PostgreSQL to
+    process the row as an update, create a new row version, creating unnecessary write
+    amplification, dead tuples, WAL, and potential table and index bloats.
+
+    In most cases, this assignment is redundant or indicates that a different value was
+    intended.
+
+    ## **When should you?**
+    Almost never. Intentional self-assignments are rare and are typically used only to
+    force UPDATE semantics, such as firing triggers.
+
+    ## **Use instead:**
+    Use the correct value or remove the assignment entirely.
+    """
+
+    def visit_ResTarget(
+        self,
+        ancestors: visitors.Ancestor,
+        node: ast.ResTarget,
+    ) -> None:
+        """Visit ResTarget."""
+        if (
+            ancestors.find_nearest(ast.UpdateStmt)
+            and isinstance(node.val, ast.ColumnRef)
+            and node.name == get_fully_qualified_name(node.val.fields)
+        ):
+            self.violations.add(
+                linter.Violation(
+                    rule_code=self.code,
+                    rule_name=self.name,
+                    rule_category=self.category,
+                    line_number=self.line_number,
+                    column_offset=self.column_offset,
+                    line=self.line,
+                    statement_location=self.statement_location,
+                    description="Self assigning column",
+                    is_auto_fixable=self.is_auto_fixable,
+                    is_fix_enabled=self.is_fix_enabled,
+                    help="Avoid self-assignments in UPDATE statements",
+                ),
+            )

--- a/src/pgrubic/rules/general/GN036.py
+++ b/src/pgrubic/rules/general/GN036.py
@@ -2,7 +2,6 @@
 
 from pglast import ast, visitors
 
-from pgrubic import get_fully_qualified_name
 from pgrubic.core import linter
 
 
@@ -26,17 +25,83 @@ class SelfAssigningColumn(linter.BaseChecker):
     Use the correct value or remove the assignment entirely.
     """
 
+    def _target_alias(self, update_statement: visitors.Ancestor) -> str:
+        """Get the target alias of the update statement."""
+        relation = update_statement.node.relation
+
+        if relation.alias is not None:
+            return str(relation.alias.aliasname)
+
+        return str(relation.relname)
+
+    def _is_self_assignment(
+        self,
+        update_statement: visitors.Ancestor,
+        column: ast.ColumnRef,
+    ) -> bool:
+        """Check if the assignment is a self-assignment."""
+        fields = [field.sval for field in column.fields]
+        target_column = column.fields[-1].sval
+
+        unqualified_column_length = 1
+        table_qualified_column_length = 2
+        schema_table_qualified_column_length = 3
+        catalog_schema_table_qualified_column_length = 4
+
+        # column
+        if len(fields) == unqualified_column_length:
+            return bool(fields[0] == target_column)
+
+        # alias.column/table.column
+        if len(fields) == table_qualified_column_length:
+            relation, column = fields
+
+            return bool(
+                column == target_column
+                and relation
+                == self._target_alias(
+                    update_statement,
+                ),
+            )
+
+        # schema.table.column
+        if len(fields) == schema_table_qualified_column_length:
+            schema, table, column = fields
+            relation = update_statement.node.relation
+
+            return bool(
+                column == target_column
+                and schema == relation.schemaname
+                and table == relation.relname,
+            )
+
+        # catalog.schema.table.column
+        if len(fields) == catalog_schema_table_qualified_column_length:
+            catalog, schema, table, column = fields
+
+            relation = update_statement.node.relation
+
+            return bool(
+                column == target_column
+                and catalog == relation.catalogname
+                and schema == relation.schemaname
+                and table == relation.relname,
+            )
+
+        return False
+
     def visit_ResTarget(
         self,
         ancestors: visitors.Ancestor,
         node: ast.ResTarget,
     ) -> None:
         """Visit ResTarget."""
-        if (
-            ancestors.find_nearest(ast.UpdateStmt)
-            and isinstance(node.val, ast.ColumnRef)
-            and node.name == get_fully_qualified_name(node.val.fields)
-        ):
+        update_stmt = ancestors.find_nearest(ast.UpdateStmt)
+
+        if not update_stmt or not isinstance(node.val, ast.ColumnRef):
+            return
+
+        if self._is_self_assignment(update_stmt, node.val):
             self.violations.add(
                 linter.Violation(
                     rule_code=self.code,

--- a/src/pgrubic/rules/general/GN036.py
+++ b/src/pgrubic/rules/general/GN036.py
@@ -1,4 +1,4 @@
-"""Checker for self assigning column."""
+"""Checker for self-assigning column."""
 
 from pglast import ast, visitors
 
@@ -7,7 +7,7 @@ from pgrubic.core import linter
 
 class SelfAssigningColumn(linter.BaseChecker):
     """## **What it does**
-    Checks for self assigning columns.
+    Checks for self-assigning columns.
 
     ## **Why not?**
     Assigning a column to itself does not change its value but still causes PostgreSQL to
@@ -84,12 +84,12 @@ class SelfAssigningColumn(linter.BaseChecker):
 
             return bool(
                 column == target_column
-                and catalog == relation.catalogname
+                and (not relation.catalogname or catalog == relation.catalogname)
                 and schema == relation.schemaname
                 and table == relation.relname,
             )
 
-        return False
+        return False  # pragma: no cover
 
     def visit_ResTarget(
         self,
@@ -116,7 +116,7 @@ class SelfAssigningColumn(linter.BaseChecker):
                     column_offset=self.column_offset,
                     line=self.line,
                     statement_location=self.statement_location,
-                    description="Self assigning column",
+                    description="Self-assigning column",
                     is_auto_fixable=self.is_auto_fixable,
                     is_fix_enabled=self.is_fix_enabled,
                     help="Avoid self-assignments in UPDATE statements",

--- a/src/pgrubic/rules/general/GN036.py
+++ b/src/pgrubic/rules/general/GN036.py
@@ -25,9 +25,9 @@ class SelfAssigningColumn(linter.BaseChecker):
     Use the correct value or remove the assignment entirely.
     """
 
-    def _target_alias(self, update_statement: visitors.Ancestor) -> str:
+    def _target_alias(self, update_statement: ast.UpdateStmt) -> str:
         """Get the target alias of the update statement."""
-        relation = update_statement.node.relation
+        relation = update_statement.relation
 
         if relation.alias is not None:
             return str(relation.alias.aliasname)
@@ -36,12 +36,13 @@ class SelfAssigningColumn(linter.BaseChecker):
 
     def _is_self_assignment(
         self,
-        update_statement: visitors.Ancestor,
-        column: ast.ColumnRef,
+        *,
+        node: ast.UpdateStmt,
+        target_column: str,
+        expression: ast.ColumnRef,
     ) -> bool:
         """Check if the assignment is a self-assignment."""
-        fields = [field.sval for field in column.fields]
-        target_column = column.fields[-1].sval
+        fields = [field.sval for field in expression.fields]
 
         unqualified_column_length = 1
         table_qualified_column_length = 2
@@ -60,14 +61,14 @@ class SelfAssigningColumn(linter.BaseChecker):
                 column == target_column
                 and relation
                 == self._target_alias(
-                    update_statement,
+                    node,
                 ),
             )
 
         # schema.table.column
         if len(fields) == schema_table_qualified_column_length:
             schema, table, column = fields
-            relation = update_statement.node.relation
+            relation = node.relation
 
             return bool(
                 column == target_column
@@ -79,7 +80,7 @@ class SelfAssigningColumn(linter.BaseChecker):
         if len(fields) == catalog_schema_table_qualified_column_length:
             catalog, schema, table, column = fields
 
-            relation = update_statement.node.relation
+            relation = node.relation
 
             return bool(
                 column == target_column
@@ -96,12 +97,16 @@ class SelfAssigningColumn(linter.BaseChecker):
         node: ast.ResTarget,
     ) -> None:
         """Visit ResTarget."""
-        update_stmt = ancestors.find_nearest(ast.UpdateStmt)
+        update_statement = ancestors.find_nearest(ast.UpdateStmt)
 
-        if not update_stmt or not isinstance(node.val, ast.ColumnRef):
+        if not update_statement or not isinstance(node.val, ast.ColumnRef):
             return
 
-        if self._is_self_assignment(update_stmt, node.val):
+        if self._is_self_assignment(
+            node=update_statement.node,
+            target_column=node.name,
+            expression=node.val,
+        ):
             self.violations.add(
                 linter.Violation(
                     rule_code=self.code,

--- a/src/pgrubic/rules/general/GN036.py
+++ b/src/pgrubic/rules/general/GN036.py
@@ -99,7 +99,16 @@ class SelfAssigningColumn(linter.BaseChecker):
         """Visit ResTarget."""
         update_statement = ancestors.find_nearest(ast.UpdateStmt)
 
-        if not update_statement or not isinstance(node.val, ast.ColumnRef):
+        if not update_statement:
+            return
+
+        target_list = update_statement.node.targetList or []
+
+        if (
+            node not in target_list
+            or not node.name
+            or not isinstance(node.val, ast.ColumnRef)
+        ):
             return
 
         if self._is_self_assignment(

--- a/tests/fixtures/rules/general/GN036.yml
+++ b/tests/fixtures/rules/general/GN036.yml
@@ -1,28 +1,82 @@
 ---
 rule: GN036
 
-test_pass_select_self_assignment:
+test_pass_select_column_equality:
   sql_pass: |
     SELECT a = a;
 
-test_fail_update_self_assignment:
+test_fail_self_assignment:
   sql_fail: |
     UPDATE tbl
        SET a = a;
 
-# test_fail_inequality_update_self_assignment:
-#   sql_fail: |
-#     UPDATE table tbl
-#        SET a != a;
+test_fail_self_assignment_with_table_qualifier:
+  sql_fail: |
+    UPDATE tbl
+       SET a = tbl.a;
 
-# test_pass_is_null:
-#   sql_pass: |
-#     SELECT a IS NULL;
+test_fail_self_assignment_with_table_alias:
+  sql_fail: |
+    UPDATE tbl AS t
+       SET a = t.a;
 
-# test_pass_is_not_null:
-#   sql_pass: |
-#     SELECT a IS NOT NULL;
+test_fail_self_assignment_with_table_schema_qualifier:
+  sql_fail: |
+    UPDATE public.tbl
+       SET a = public.tbl.a;
 
-# test_pass_comparison_with_stringified_null:
-#   sql_pass: |
-#     SELECT a = 'NULL';
+test_fail_self_assignment_with_table_schema_database_qualifier:
+  sql_fail: |
+    UPDATE postgres.public.tbl
+       SET a = postgres.public.tbl.a;
+
+test_fail_self_assignment_from_other_table:
+  sql_fail: |
+    UPDATE tbl AS t
+       SET a = t.a
+      FROM other;
+
+test_pass_assignment_from_other_table:
+  sql_pass: |
+    UPDATE tbl AS t
+       SET a = other.a
+      FROM other;
+
+test_pass_assignment_from_other_table_with_alias:
+  sql_pass: |
+    UPDATE tbl AS t
+       SET a = o.a
+      FROM other AS o;
+
+test_pass_assignment_with_target_table_dependent_on_search_path:
+  sql_pass: |
+    UPDATE tbl
+       SET a = public.tbl.a
+      FROM other.tbl;
+
+test_fail_self_assignment_with_target_table_schema_missing_column_schema:
+  sql_fail: |
+    UPDATE public.tbl
+       SET a = tbl.a;
+
+test_fail_self_assignment_with_target_table_schema_database_missing_column_database:
+  sql_fail: |
+    UPDATE postgres.public.tbl
+       SET a = public.tbl.a;
+
+test_fail_self_assignment_with_target_table_schema_database_missing_column_database_schema:
+  sql_fail: |
+    UPDATE postgres.public.tbl
+       SET a = tbl.a;
+
+test_fail_self_assignment_with_target_table_schema_missing_column_schema_ambiguous_table:
+  sql_fail: |
+    UPDATE public.tbl
+       SET a = tbl.a
+      FROM other.tbl;
+
+test_fail_self_assignment_with_target_table_schema_database_missing_column_database_schema_ambiguous_table:
+  sql_fail: |
+    UPDATE postgres.public.tbl
+       SET a = tbl.a
+      FROM other.tbl;

--- a/tests/fixtures/rules/general/GN036.yml
+++ b/tests/fixtures/rules/general/GN036.yml
@@ -95,3 +95,36 @@ test_fail_self_assignment_with_target_table_schema_column_database_schema:
   sql_fail: |
     UPDATE public.tbl
        SET a = postgres.public.tbl.a;
+
+test_fail_returning_clause_with_self_assignment:
+  sql_fail: |
+    UPDATE tbl
+       SET a = a
+     RETURNING *;
+
+test_pass_returning_clause_asterisk:
+  sql_pass: |
+    UPDATE tbl
+       SET a = b
+     RETURNING *;
+
+test_pass_returning_clause_non_asterisk:
+  sql_pass: |
+    UPDATE tbl
+       SET a = b
+     RETURNING a AS a;
+
+test_pass_subquery_with_self_assignment:
+  sql_pass: |
+    UPDATE tbl
+       SET a = (SELECT a FROM tbl WHERE id = 1);
+
+test_pass_constant_assignment:
+  sql_pass: |
+    UPDATE tbl
+       SET a = 1;
+
+test_pass_scalar_assignment:
+  sql_pass: |
+    UPDATE tbl
+       SET a = 'apple';

--- a/tests/fixtures/rules/general/GN036.yml
+++ b/tests/fixtures/rules/general/GN036.yml
@@ -1,0 +1,28 @@
+---
+rule: GN036
+
+test_pass_select_self_assignment:
+  sql_pass: |
+    SELECT a = a;
+
+test_fail_update_self_assignment:
+  sql_fail: |
+    UPDATE tbl
+       SET a = a;
+
+# test_fail_inequality_update_self_assignment:
+#   sql_fail: |
+#     UPDATE table tbl
+#        SET a != a;
+
+# test_pass_is_null:
+#   sql_pass: |
+#     SELECT a IS NULL;
+
+# test_pass_is_not_null:
+#   sql_pass: |
+#     SELECT a IS NOT NULL;
+
+# test_pass_comparison_with_stringified_null:
+#   sql_pass: |
+#     SELECT a = 'NULL';

--- a/tests/fixtures/rules/general/GN036.yml
+++ b/tests/fixtures/rules/general/GN036.yml
@@ -10,6 +10,11 @@ test_pass_non_self_assignment:
     UPDATE tbl
       SET a = b;
 
+test_pass_non_self_assignment_expression:
+  sql_pass: |
+    UPDATE tbl
+      SET a = a + 1;
+
 test_fail_self_assignment:
   sql_fail: |
     UPDATE tbl
@@ -85,3 +90,8 @@ test_fail_self_assignment_with_target_table_schema_database_missing_column_datab
     UPDATE postgres.public.tbl
        SET a = tbl.a
       FROM other.tbl;
+
+test_fail_self_assignment_with_target_table_schema_column_database_schema:
+  sql_fail: |
+    UPDATE public.tbl
+       SET a = postgres.public.tbl.a;

--- a/tests/fixtures/rules/general/GN036.yml
+++ b/tests/fixtures/rules/general/GN036.yml
@@ -5,6 +5,11 @@ test_pass_select_column_equality:
   sql_pass: |
     SELECT a = a;
 
+test_pass_non_self_assignment:
+  sql_pass: |
+    UPDATE tbl
+      SET a = b;
+
 test_fail_self_assignment:
   sql_fail: |
     UPDATE tbl

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -5,8 +5,8 @@ from pgrubic import core
 
 def test_load_rules(linter: core.Linter) -> None:
     """Test loading rules."""
-    expected_active_rules = 113
-    expected_total_rules = 114
+    expected_active_rules = 114
+    expected_total_rules = 115
 
     active_rules = core.load_rules(config=linter.config)
     all_rules = core.load_rules(config=linter.config, include_deprecated=True)


### PR DESCRIPTION
## Background and Motivation
<!-- Why is this change needed? What problem does it solve? -->
This PR adds a new lint rule (GN036) to detect self-assigning column updates (e.g., `UPDATE ... SET a = a`) and updates the test suite/fixtures to include the new rule.
## Summary of Changes
<!-- High-level overview of what was changed. -->
- Added new rule `GN036` (`SelfAssigningColumn`) to flag self-assignments in `UPDATE` statements.
- Added YAML fixture test cases for `GN036`.
- Updated loader test expectations to account for the additional rule.
## Type of change
<!-- Select the type of change. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Housekeeping (change that does not affect functionality)

## SQL Examples (if applicable)
<!-- Provide sample SQL to show before/after behavior of the linter/formatter. -->

```sql
-- Before (No violations)
UPDATE tbl
   SET a = a;

-- After (Violations)
UPDATE tbl
   SET a = a;
```

## Checklist
<!-- Checklist before requesting a review -->
- [x] I have read and followed the [contributing guidelines](https://github.com/bolajiwahab/pgrubic/blob/main/docs/docs/contributing.md)
- [x] I have checked that there are no other open [Pull Requests](https://github.com/bolajiwahab/pgrubic/pulls) for the same update/change
- [x] I have performed a self-review of my code
- [x] I have added/updated tests (positive + negative cases)
- [x] I have updated documentation (if applicable)

## Closes / Fixes
<!-- Link issues using keywords: Closes #123, Fixes #456 -->

## Additional information
<!-- Provide any additional information that might be helpful to the reviewer in reviewing this pull request -->
