### PR TITLE
feat: support config overrides

### DIFF
--- a/src/pgrubic/core/config.py
+++ b/src/pgrubic/core/config.py
@@ -871,6 +871,11 @@ def _load_user_config() -> dict[str, typing.Any]:
 def _merge_config(*, overrides: dict[str, typing.Any]) -> dict[str, typing.Any]:
     """Merge default and user config, with overrides.
 
+    Parameters:
+    ----------
+    overrides: dict[str, typing.Any]
+        Overrides applied on top of the user config.
+
     Returns:
     -------
     dict[str, typing.Any]
@@ -941,7 +946,7 @@ def parse_config(overrides: dict[str, typing.Any] | None = None) -> Config:
     Parameters
     ----------
     overrides : dict[str, typing.Any] | None, optional
-        The overrides to apply to the config, by default None
+        Overrides applied on top of the user config.
 
     Returns:
     -------

--- a/src/pgrubic/core/config.py
+++ b/src/pgrubic/core/config.py
@@ -945,7 +945,7 @@ def parse_config(overrides: dict[str, typing.Any] | None = None) -> Config:
 
     Parameters
     ----------
-    overrides : dict[str, typing.Any] | None, optional
+    overrides: dict[str, typing.Any] | None, optional
         Overrides applied on top of the user config.
 
     Returns:

--- a/src/pgrubic/core/config.py
+++ b/src/pgrubic/core/config.py
@@ -943,7 +943,7 @@ def _get_config_file_absolute_path(
 def parse_config(overrides: dict[str, typing.Any] | None = None) -> Config:
     """Parse config.
 
-    Parameters
+    Parameters:
     ----------
     overrides: dict[str, typing.Any] | None, optional
         Overrides applied on top of the user config.

--- a/src/pgrubic/core/config.py
+++ b/src/pgrubic/core/config.py
@@ -868,15 +868,20 @@ def _load_user_config() -> dict[str, typing.Any]:
     return {}  # pragma: no cover
 
 
-def _merge_config() -> dict[str, typing.Any]:
-    """Merge default and user config.
+def _merge_config(*, overrides: dict[str, typing.Any]) -> dict[str, typing.Any]:
+    """Merge default and user config, with overrides.
 
     Returns:
     -------
     dict[str, typing.Any]
         The merged config.
     """
-    return dict(always_merger.merge(_load_default_config(), _load_user_config()))
+    return dict(
+        always_merger.merge(
+            _load_default_config(),
+            always_merger.merge(_load_user_config(), overrides),
+        ),
+    )
 
 
 def _get_config_file_absolute_path(
@@ -930,8 +935,13 @@ def _get_config_file_absolute_path(
     return None  # pragma: no cover
 
 
-def parse_config() -> Config:
+def parse_config(overrides: dict[str, typing.Any] | None = None) -> Config:
     """Parse config.
+
+    Parameters
+    ----------
+    overrides : dict[str, typing.Any] | None, optional
+        The overrides to apply to the config, by default None
 
     Returns:
     -------
@@ -943,7 +953,10 @@ def parse_config() -> Config:
     MissingConfigError
         Raised when a config is missing.
     """
-    merged_config = _merge_config()
+    if not overrides:
+        overrides = {}
+
+    merged_config = _merge_config(overrides=overrides)
     config_lint = merged_config["lint"]
     config_format = merged_config["format"]
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -108,3 +108,23 @@ def test_config_parse_error(tmp_path: pathlib.Path) -> None:
             excinfo.value.args[0]
             == f"""Error parsing configuration file "{config_file}\""""
         )
+
+
+def test_config_user_overrides(tmp_path: pathlib.Path) -> None:
+    """Test config user overrides."""
+    config_content = """
+    [lint]
+    fix = false
+    """
+    directory = tmp_path / "sub"
+    directory.mkdir()
+
+    config_file = directory / config.CONFIG_FILE
+    config_file.write_text(config_content)
+
+    with patch.dict(
+        "os.environ",
+        {config.CONFIG_PATH_ENVIRONMENT_VARIABLE: str(directory)},
+    ):
+        parsed_config = config.parse_config(overrides={"lint": {"fix": True}})
+        assert parsed_config.lint.fix is True


### PR DESCRIPTION
## Background and Motivation
<!-- Why is this change needed? What problem does it solve? -->
Adds support for applying caller-provided configuration overrides on top of the existing default + user TOML configuration merge, enabling runtime customization without editing config files.

## Summary of Changes
<!-- High-level overview of what was changed. -->
- Extend `parse_config()` to accept an optional `overrides` dictionary.
- Update config merging so overrides take precedence over user config, which takes precedence over defaults.


## Type of change
<!-- Select the type of change. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Housekeeping (change that does not affect functionality)

## SQL Examples (if applicable)
<!-- Provide sample SQL to show before/after behavior of the linter/formatter. -->

```sql
-- Before
...

-- After
...
```

## Checklist
<!-- Checklist before requesting a review -->
- [x] I have read and followed the [contributing guidelines](https://github.com/bolajiwahab/pgrubic/blob/main/docs/docs/contributing.md)
- [x] I have checked that there are no other open [Pull Requests](https://github.com/bolajiwahab/pgrubic/pulls) for the same update/change
- [x] I have performed a self-review of my code
- [x] I have added/updated tests (positive + negative cases)
- [ ] I have updated documentation (if applicable)

## Closes / Fixes
<!-- Link issues using keywords: Closes #123, Fixes #456 -->

## Additional information
<!-- Provide any additional information that might be helpful to the reviewer in reviewing this pull request -->
