### PR TITLE
feat(formatter): Improve create index printer with adaptive list layouts and clause alignment

### DIFF
--- a/docs/docs/settings.md
+++ b/docs/docs/settings.md
@@ -591,7 +591,7 @@ comma-at-beginning = false
 </details>
 
 ### **compact-lists-margin**
-Use a compact, single-line form for a list when it does not exceed this right
+Use a compact, single-line form for a list when it does not exceed this
 margin. Set it to `0` to always expand lists.
 
 **Type**: `int`

--- a/docs/docs/settings.md
+++ b/docs/docs/settings.md
@@ -590,6 +590,24 @@ comma-at-beginning = false
 ```
 </details>
 
+### **compact-lists-margin**
+Use a compact, single-line form for a list when it does not exceed this right
+margin. Set it to `0` to always expand lists.
+
+**Type**: `int`
+
+**Default**: `90`
+
+**Example**:
+<details open>
+<summary><strong>pgrubic.toml</strong></summary>
+
+```toml
+[format]
+compact-lists-margin = 100
+```
+</details>
+
 ### **new-line-before-semicolon**
 If `true`, add a new line before each semicolon.
 

--- a/src/pgrubic/core/config.py
+++ b/src/pgrubic/core/config.py
@@ -607,6 +607,24 @@ comma-at-beginning = false
 ```
 </details>
 
+### **compact-lists-margin**
+Use a compact, single-line form for a list when it does not exceed this
+margin. Set it to `0` to always expand lists.
+
+**Type**: `int`
+
+**Default**: `90`
+
+**Example**:
+<details open>
+<summary><strong>pgrubic.toml</strong></summary>
+
+```toml
+[format]
+compact-lists-margin = 100
+```
+</details>
+
 ### **new-line-before-semicolon**
 If `true`, add a new line before each semicolon.
 
@@ -762,6 +780,7 @@ no-cache = true
     include: list[str]
     exclude: list[str]
     comma_at_beginning: bool
+    compact_lists_margin: int
     new_line_before_semicolon: bool
     lines_between_statements: int
     remove_pg_catalog_from_functions: bool
@@ -1043,6 +1062,7 @@ def parse_config(overrides: dict[str, typing.Any] | None = None) -> Config:
                 include=config_format["include"] + merged_config["include"],
                 exclude=config_format["exclude"] + merged_config["exclude"],
                 comma_at_beginning=config_format["comma-at-beginning"],
+                compact_lists_margin=config_format["compact-lists-margin"],
                 new_line_before_semicolon=config_format["new-line-before-semicolon"],
                 lines_between_statements=config_format["lines-between-statements"],
                 remove_pg_catalog_from_functions=config_format[

--- a/src/pgrubic/core/formatter.py
+++ b/src/pgrubic/core/formatter.py
@@ -2,7 +2,7 @@
 
 import typing
 
-from pglast import parser, stream
+from pglast import ast, parser, stream
 
 from pgrubic import ISSUES_URL
 from pgrubic.core import noqa, config, errors
@@ -24,6 +24,32 @@ class IndentedStream(stream.IndentedStream):
         """Initialize IndentedStream with config."""
         super().__init__(**options)
         self.config = config
+
+    def print_parenthesized_list(
+        self,
+        nodes: tuple[ast.Node, ...],
+        *,
+        closing_indent: int,
+        continuation_indent: int = 4,
+    ) -> None:
+        """Print a parenthesized list in compact or expanded form."""
+        compact_list = self._concat_nodes(nodes)
+        compact_lists_margin = self.config.format.compact_lists_margin
+        is_compact = (
+            compact_lists_margin > 0
+            and self.current_column + len("(") + len(compact_list) < compact_lists_margin
+        )
+
+        self.write("(")
+        if is_compact:
+            self.print_list(nodes, standalone_items=False)
+        else:
+            self.newline()
+            self.space(continuation_indent)
+            self.print_list(nodes, standalone_items=True)
+            self.newline()
+            self.indent(closing_indent)
+        self.write(")")
 
 
 class Formatter:

--- a/src/pgrubic/core/formatter.py
+++ b/src/pgrubic/core/formatter.py
@@ -25,6 +25,27 @@ class IndentedStream(stream.IndentedStream):
         super().__init__(**options)
         self.config = config
 
+    def _concatenate_nodes(
+        self,
+        *,
+        nodes: tuple[ast.Node, ...],
+        sep: str = noqa.SPACE,
+        are_names: bool = False,
+    ) -> str:
+        """Concatenate the given `nodes`, using `sep` as the separator."""
+        output = stream.RawStream(
+            special_functions=self.special_functions,
+            comma_at_eoln=self.comma_at_eoln,
+            remove_pg_catalog_from_functions=self.remove_pg_catalog_from_functions,
+        )
+        output.print_list(
+            nodes=nodes,
+            sep=sep,
+            standalone_items=False,
+            are_names=are_names,
+        )
+        return output.getvalue()
+
     def print_parenthesized_list(
         self,
         nodes: tuple[ast.Node, ...],
@@ -33,11 +54,12 @@ class IndentedStream(stream.IndentedStream):
         continuation_indent: int = 4,
     ) -> None:
         """Print a parenthesized list in compact or expanded form."""
-        compact_list = self._concat_nodes(nodes)
+        compact_list = self._concatenate_nodes(nodes=nodes)
         compact_lists_margin = self.config.format.compact_lists_margin
-        is_compact = (
-            compact_lists_margin > 0
-            and self.current_column + len("(") + len(compact_list) < compact_lists_margin
+        length_of_parentheses = 2
+        is_compact = compact_lists_margin > 0 and (
+            (self.current_column + len(compact_list) + length_of_parentheses)
+            <= compact_lists_margin
         )
 
         self.write("(")

--- a/src/pgrubic/formatters/ddl/index.py
+++ b/src/pgrubic/formatters/ddl/index.py
@@ -43,10 +43,12 @@ def index_stmt(node: ast.IndexStmt, output: formatter.IndentedStream) -> None:
     output.space()
     output.print_node(node.relation)
 
-    if (
+    print_access_method = (
         node.accessMethod != DEFAULT_INDEX_ACCESS_METHOD
         or not output.config.format.remove_default_index_access_method
-    ):
+    )
+
+    if print_access_method:
         output.newline()
         output.indent(gutter - len("USING"))
         output.write("USING")
@@ -54,37 +56,38 @@ def index_stmt(node: ast.IndexStmt, output: formatter.IndentedStream) -> None:
         output.print_name(node.accessMethod)
 
     output.space()
-    output.swrite("(")
-    output.print_list(node.indexParams, standalone_items=False)
-    output.swrite(")")
+    output.print_parenthesized_list(
+        node.indexParams,
+        closing_indent=gutter - len("ON"),
+    )
 
     if node.indexIncludingParams:
+        keyword = "INCLUDE"
         output.newline()
-        output.indent(gutter - len("INCLUDE"))
-        output.write("INCLUDE")
+        output.indent(gutter - len(keyword))
+        output.write(keyword)
         output.space()
-        output.swrite("(")
-        output.print_list(node.indexIncludingParams, standalone_items=False)
-        output.swrite(")")
+        output.print_parenthesized_list(
+            node.indexIncludingParams,
+            closing_indent=gutter - len(keyword),
+        )
 
     if node.nulls_not_distinct:
+        keyword = "NULLS"
         output.newline()
-        output.indent(gutter - len("NULLS"))
-        output.write("NULLS NOT DISTINCT")
+        output.indent(gutter - len(keyword))
+        output.write(f"{keyword} NOT DISTINCT")
 
     if node.options:
+        keyword = "WITH"
         output.newline()
-        output.indent(gutter - len("WITH"))
-        output.write("WITH")
+        output.indent(gutter - len(keyword))
+        output.write(keyword)
         output.space()
-        with output.expression(need_parens=True):
-            output.newline() if len(node.options) > 1 else output.space(0)
-            output.space(gutter - len("WITH") + 2) if len(
-                node.options,
-            ) > 1 else output.space(0)
-            output.print_list(node.options, standalone_items=True)
-            output.newline() if len(node.options) > 1 else output.space(0)
-            output.indent(gutter - len("WITH"))
+        output.print_parenthesized_list(
+            node.options,
+            closing_indent=gutter - len(keyword),
+        )
 
     if node.tableSpace:
         output.newline()
@@ -94,8 +97,9 @@ def index_stmt(node: ast.IndexStmt, output: formatter.IndentedStream) -> None:
         output.print_name(node.tableSpace)
 
     if node.whereClause:
+        keyword = "WHERE"
         output.newline()
-        output.indent(gutter - len("WHERE"))
-        output.write("WHERE")
+        output.indent(gutter - len(keyword))
+        output.write(keyword)
         output.space()
         output.print_node(node.whereClause)

--- a/src/pgrubic/formatters/ddl/index.py
+++ b/src/pgrubic/formatters/ddl/index.py
@@ -78,10 +78,12 @@ def index_stmt(node: ast.IndexStmt, output: formatter.IndentedStream) -> None:
         output.write("WITH")
         output.space()
         with output.expression(need_parens=True):
-            output.newline()
-            output.space(gutter - len("WITH") + 2)
+            output.newline() if len(node.options) > 1 else output.space(0)
+            output.space(gutter - len("WITH") + 2) if len(
+                node.options,
+            ) > 1 else output.space(0)
             output.print_list(node.options, standalone_items=True)
-            output.newline()
+            output.newline() if len(node.options) > 1 else output.space(0)
             output.indent(gutter - len("WITH"))
 
     if node.tableSpace:

--- a/src/pgrubic/formatters/ddl/index.py
+++ b/src/pgrubic/formatters/ddl/index.py
@@ -8,6 +8,7 @@ from pgrubic.core import formatter
 from pgrubic.formatters.ddl import IF_NOT_EXISTS
 
 DEFAULT_INDEX_ACCESS_METHOD: typing.Final[str] = "btree"
+DEFAULT_GUTTER: typing.Final[int] = 6
 
 
 @printers.node_printer(ast.IndexStmt, override=True)
@@ -34,59 +35,65 @@ def index_stmt(node: ast.IndexStmt, output: formatter.IndentedStream) -> None:
         output.space()
         output.print_name(node.idxname)
 
+    gutter = 10 if node.tableSpace else 7 if node.indexIncludingParams else DEFAULT_GUTTER
+
     output.newline()
+    output.indent(gutter - len("ON"))
+    output.write("ON")
+    output.space()
+    output.print_node(node.relation)
 
-    with output.push_indent(4):
-        output.write("ON")
+    if (
+        node.accessMethod != DEFAULT_INDEX_ACCESS_METHOD
+        or not output.config.format.remove_default_index_access_method
+    ):
+        output.newline()
+        output.indent(gutter - len("USING"))
+        output.write("USING")
         output.space()
-        output.print_node(node.relation)
+        output.print_name(node.accessMethod)
 
-        if (
-            node.accessMethod != DEFAULT_INDEX_ACCESS_METHOD
-            or not output.config.format.remove_default_index_access_method
-        ):
-            output.newline()
-            output.indent(1)
-            output.write("USING")
-            output.space()
-            output.print_name(node.accessMethod)
+    output.space()
+    output.swrite("(")
+    output.print_list(node.indexParams, standalone_items=False)
+    output.swrite(")")
 
+    if node.indexIncludingParams:
+        output.newline()
+        output.indent(gutter - len("INCLUDE"))
+        output.write("INCLUDE")
         output.space()
         output.swrite("(")
-        output.print_list(node.indexParams, standalone_items=False)
+        output.print_list(node.indexIncludingParams, standalone_items=False)
         output.swrite(")")
 
-        if node.indexIncludingParams:
-            output.space()
-            output.write("INCLUDE")
-            output.space()
-            output.swrite("(")
-            output.print_list(node.indexIncludingParams, standalone_items=False)
-            output.swrite(")")
+    if node.nulls_not_distinct:
+        output.newline()
+        output.indent(gutter - len("NULLS"))
+        output.write("NULLS NOT DISTINCT")
 
-        if node.nulls_not_distinct:
+    if node.options:
+        output.newline()
+        output.indent(gutter - len("WITH"))
+        output.write("WITH")
+        output.space()
+        with output.expression(need_parens=True):
             output.newline()
-            output.indent(1)
-            output.write("NULLS NOT DISTINCT")
+            output.space(gutter - len("WITH") + 2)
+            output.print_list(node.options, standalone_items=True)
+            output.newline()
+            output.indent(gutter - len("WITH"))
 
-        if node.options:
-            output.newline()
-            output.indent(2)
-            output.write("WITH")
-            output.space()
-            with output.expression(need_parens=True):
-                output.print_list(node.options, standalone_items=False)
+    if node.tableSpace:
+        output.newline()
+        output.indent()
+        output.write("TABLESPACE")
+        output.space()
+        output.print_name(node.tableSpace)
 
-        if node.tableSpace:
-            output.newline()
-            output.indent()
-            output.write("TABLESPACE")
-            output.space()
-            output.print_name(node.tableSpace)
-
-        if node.whereClause:
-            output.newline()
-            output.indent(1)
-            output.write("WHERE")
-            output.space()
-            output.print_node(node.whereClause)
+    if node.whereClause:
+        output.newline()
+        output.indent(gutter - len("WHERE"))
+        output.write("WHERE")
+        output.space()
+        output.print_node(node.whereClause)

--- a/src/pgrubic/pgrubic.toml
+++ b/src/pgrubic/pgrubic.toml
@@ -33,6 +33,7 @@ regex-sequence = "^.+$"
 include = []
 exclude = []
 comma-at-beginning = true
+compact-lists-margin = 90
 new-line-before-semicolon = false
 remove-pg-catalog-from-functions = true
 remove-default-index-access-method = true

--- a/tests/fixtures/formatters/ddl/index.yml
+++ b/tests/fixtures/formatters/ddl/index.yml
@@ -143,6 +143,17 @@ create_index_within_line_length:
     format:
       compact_lists_margin: 100
 
+create_index_at_compact_list_margin:
+  sql: |
+    CREATE INDEX idx_orders ON orders (id) INCLUDE (first_name, last_name);
+  expected: |
+    CREATE INDEX idx_orders
+         ON orders (id)
+    INCLUDE (first_name, last_name);
+  config:
+    format:
+      compact_lists_margin: 31
+
 create_index_remove_default_method:
   sql: |
     CREATE INDEX idx_orders ON orders USING btree (id);
@@ -153,3 +164,20 @@ create_index_remove_default_method:
   config:
     format:
       remove_default_index_access_method: false
+
+create_index_without_compact_lists:
+  sql: |
+    CREATE INDEX idx_orders ON orders (id) INCLUDE (first_name, last_name);
+  expected: |
+    CREATE INDEX idx_orders
+         ON orders (
+             id
+         )
+    INCLUDE (
+        first_name
+      , last_name
+    );
+  config:
+    format:
+      compact_lists_margin: 0
+      remove_default_index_access_method: true

--- a/tests/fixtures/formatters/ddl/index.yml
+++ b/tests/fixtures/formatters/ddl/index.yml
@@ -5,8 +5,60 @@ formatter: INDEX
 create_index:
   sql: |
     CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS
-    idx_orders ON orders USING btree (id ASC NULLS LAST, status COLLATE pg_catalog."default" ASC NULLS LAST)
+    idx_orders ON orders USING btree (id ASC NULLS LAST)
     INCLUDE (first_name, last_name)
+    NULLS NOT DISTINCT
+    WITH (fillfactor = 90, deduplicate_items = off)
+    TABLESPACE pg_default
+    WHERE name IS NOT NULL;
+  expected: |
+    CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS idx_orders
+            ON orders (id ASC NULLS LAST)
+       INCLUDE (first_name, last_name)
+         NULLS NOT DISTINCT
+          WITH (fillfactor = 90, deduplicate_items = off)
+    TABLESPACE pg_default
+         WHERE name IS NOT NULL;
+
+create_index_long_lists:
+  sql: |
+    CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS idx_orders ON orders (account_identifier ASC NULLS LAST, customer_identifier ASC NULLS LAST, order_reference ASC NULLS LAST)
+    INCLUDE (first_name, last_name, preferred_name, billing_address, shipping_address, customer_reference)
+    NULLS NOT DISTINCT
+    WITH (fillfactor = 90, deduplicate_items = off, fastupdate = off, autosummarize = on, gin_pending_list_limit = 4096)
+    TABLESPACE pg_default
+    WHERE name IS NOT NULL;
+  expected: |
+    CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS idx_orders
+            ON orders (
+                account_identifier ASC NULLS LAST
+              , customer_identifier ASC NULLS LAST
+              , order_reference ASC NULLS LAST
+            )
+       INCLUDE (
+           first_name
+         , last_name
+         , preferred_name
+         , billing_address
+         , shipping_address
+         , customer_reference
+       )
+         NULLS NOT DISTINCT
+          WITH (
+              fillfactor = 90
+            , deduplicate_items = off
+            , fastupdate = off
+            , autosummarize = 'on'
+            , gin_pending_list_limit = 4096
+          )
+    TABLESPACE pg_default
+         WHERE name IS NOT NULL;
+
+create_index_single_item_parentheses:
+  sql: |
+    CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS
+    idx_orders ON orders USING btree (id ASC NULLS LAST)
+    INCLUDE (first_name)
     NULLS NOT DISTINCT
     WITH (fillfactor = 90)
     TABLESPACE pg_default
@@ -14,12 +66,9 @@ create_index:
   expected: |
     CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS idx_orders
             ON orders (id ASC NULLS LAST)
-       INCLUDE (name)
+       INCLUDE (first_name)
          NULLS NOT DISTINCT
-          WITH (
-                  fillfactor = 90
-                , deduplicate_items = off
-          )
+          WITH (fillfactor = 90)
     TABLESPACE pg_default
          WHERE name IS NOT NULL;
 
@@ -68,6 +117,31 @@ create_index_no_name:
   expected: |
     CREATE INDEX
         ON orders (id);
+
+create_index_custom_line_length:
+  sql: |
+    CREATE INDEX idx_orders ON orders (id) INCLUDE (first_name, last_name);
+  expected: |
+    CREATE INDEX idx_orders
+         ON orders (id)
+    INCLUDE (
+        first_name
+      , last_name
+    );
+  config:
+    format:
+      compact_lists_margin: 30
+
+create_index_within_line_length:
+  sql: |
+    CREATE INDEX idx_orders ON orders (id) INCLUDE (first_name, last_name);
+  expected: |
+    CREATE INDEX idx_orders
+         ON orders (id)
+    INCLUDE (first_name, last_name);
+  config:
+    format:
+      compact_lists_margin: 100
 
 create_index_remove_default_method:
   sql: |

--- a/tests/fixtures/formatters/ddl/index.yml
+++ b/tests/fixtures/formatters/ddl/index.yml
@@ -12,11 +12,15 @@ create_index:
     WHERE name IS NOT NULL;
   expected: |
     CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS idx_orders
-        ON orders (id ASC NULLS LAST) INCLUDE (name)
-     NULLS NOT DISTINCT
-      WITH (fillfactor = 90, deduplicate_items = off)
+            ON orders (id ASC NULLS LAST)
+       INCLUDE (name)
+         NULLS NOT DISTINCT
+          WITH (
+                  fillfactor = 90
+                , deduplicate_items = off
+          )
     TABLESPACE pg_default
-     WHERE name IS NOT NULL;
+         WHERE name IS NOT NULL;
 
 create_index_btree:
   sql: |

--- a/tests/fixtures/formatters/ddl/index.yml
+++ b/tests/fixtures/formatters/ddl/index.yml
@@ -1,13 +1,14 @@
 ---
+# yamllint disable rule:line-length
 formatter: INDEX
 
 create_index:
   sql: |
     CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS
-    idx_orders ON orders USING btree (id ASC NULLS LAST)
-    INCLUDE (name)
+    idx_orders ON orders USING btree (id ASC NULLS LAST, status COLLATE pg_catalog."default" ASC NULLS LAST)
+    INCLUDE (first_name, last_name)
     NULLS NOT DISTINCT
-    WITH (fillfactor = 90, deduplicate_items = off)
+    WITH (fillfactor = 90)
     TABLESPACE pg_default
     WHERE name IS NOT NULL;
   expected: |

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -30,9 +30,11 @@ def test_config_from_environment_variable(tmp_path: pathlib.Path) -> None:
 
 def test_config_from_current_working_directory(tmp_path: pathlib.Path) -> None:
     """Test config from current working directory."""
+    expected_compact_lists_margin = 100
     config_content = """
     [format]
     diff = true
+    compact-lists-margin = 100
     """
     directory = tmp_path / "sub"
     directory.mkdir()
@@ -45,6 +47,7 @@ def test_config_from_current_working_directory(tmp_path: pathlib.Path) -> None:
 
         parsed_config = config.parse_config()
         assert parsed_config.format.diff is True
+        assert parsed_config.format.compact_lists_margin == expected_compact_lists_margin
 
 
 def test_missing_config_error(tmp_path: pathlib.Path) -> None:


### PR DESCRIPTION
## Background and Motivation
<!-- Why is this change needed? What problem does it solve? -->
**CREATE INDEX** statements can contain several variable-length clauses, including index columns, included columns, storage parameters, tablespaces, and predicates. The previous formatter used mostly fixed indentation and inline lists, which produced inconsistent alignment and made complex indexes harder to scan.
This change introduces reusable parenthesized-list formatting that uses **compact-lists-margin** to keep short lists inline while expanding longer lists across multiple lines. It also calculates the clause gutter dynamically, giving CREATE INDEX statements consistent alignment regardless of which optional clauses are present.

## Summary of Changes
<!-- High-level overview of what was changed. -->
- Adds reusable formatter helpers for rendering AST node lists and choosing between compact and multiline parenthesized layouts based on **compact_lists_margin** config option.
- Refactors CREATE INDEX formatting to align clauses using a dynamic gutter determined by the longest applicable keyword.
- Applies consistent formatting to index columns, INCLUDE columns, and storage parameters.
- Keeps short or single-item lists inline when they fit within the configured margin and expands longer lists across multiple lines.
- Preserves configurable handling of the default btree access method.
- Improves alignment for ON, USING, INCLUDE, NULLS NOT DISTINCT, WITH, TABLESPACE, and WHERE clauses.

## Type of change
<!-- Select the type of change. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Housekeeping (change that does not affect functionality)

## SQL Examples (if applicable)
<!-- Provide sample SQL to show before/after behavior of the linter/formatter. -->

```sql
-- Before
    CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS idx_orders
        ON orders (id ASC NULLS LAST) INCLUDE (name)
     NULLS NOT DISTINCT
      WITH (fillfactor = 90, deduplicate_items = off)
    TABLESPACE pg_default
     WHERE name IS NOT NULL;

-- After
    CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS idx_orders
            ON orders (id ASC NULLS LAST)
       INCLUDE (first_name, last_name)
         NULLS NOT DISTINCT
          WITH (fillfactor = 90, deduplicate_items = off)
    TABLESPACE pg_default
         WHERE name IS NOT NULL;

```

## Checklist
<!-- Checklist before requesting a review -->
- [x] I have read and followed the [contributing guidelines](https://github.com/bolajiwahab/pgrubic/blob/main/docs/docs/contributing.md)
- [x] I have checked that there are no other open [Pull Requests](https://github.com/bolajiwahab/pgrubic/pulls) for the same update/change
- [x] I have performed a self-review of my code
- [x] I have added/updated tests (positive + negative cases)
- [x] I have updated documentation (if applicable)

## Closes / Fixes
<!-- Link issues using keywords: Closes #123, Fixes #456 -->

## Additional information
<!-- Provide any additional information that might be helpful to the reviewer in reviewing this pull request -->
