### PR TITLE
feat: Add configurable uppercase and lowercase SQL keyword formatting

### DIFF
--- a/docs/docs/settings.md
+++ b/docs/docs/settings.md
@@ -608,6 +608,24 @@ compact-parenthesized-lists-margin = 100
 ```
 </details>
 
+### **uppercase-keywords**
+Whether to format SQL keywords in uppercase. When `false`, keywords are formatted in
+lowercase.
+
+**Type**: `bool`
+
+**Default**: `true`
+
+**Example**:
+<details open>
+<summary><strong>pgrubic.toml</strong></summary>
+
+```toml
+[format]
+uppercase-keywords = false
+```
+</details>
+
 ### **new-line-before-semicolon**
 If `true`, add a new line before each semicolon.
 

--- a/src/pgrubic/core/config.py
+++ b/src/pgrubic/core/config.py
@@ -625,6 +625,24 @@ compact-parenthesized-lists-margin = 100
 ```
 </details>
 
+### **uppercase-keywords**
+Whether to format SQL keywords in uppercase. When `false`, keywords are formatted in
+lowercase.
+
+**Type**: `bool`
+
+**Default**: `true`
+
+**Example**:
+<details open>
+<summary><strong>pgrubic.toml</strong></summary>
+
+```toml
+[format]
+uppercase-keywords = false
+```
+</details>
+
 ### **new-line-before-semicolon**
 If `true`, add a new line before each semicolon.
 
@@ -781,6 +799,7 @@ no-cache = true
     exclude: list[str]
     comma_at_beginning: bool
     compact_parenthesized_lists_margin: int
+    uppercase_keywords: bool
     new_line_before_semicolon: bool
     lines_between_statements: int
     remove_pg_catalog_from_functions: bool
@@ -1065,6 +1084,7 @@ def parse_config(overrides: dict[str, typing.Any] | None = None) -> Config:
                 compact_parenthesized_lists_margin=config_format[
                     "compact-parenthesized-lists-margin"
                 ],
+                uppercase_keywords=config_format["uppercase-keywords"],
                 new_line_before_semicolon=config_format["new-line-before-semicolon"],
                 lines_between_statements=config_format["lines-between-statements"],
                 remove_pg_catalog_from_functions=config_format[

--- a/src/pgrubic/core/formatter.py
+++ b/src/pgrubic/core/formatter.py
@@ -25,6 +25,31 @@ class IndentedStream(stream.IndentedStream):
         super().__init__(**options)
         self.config = config
 
+    def apply_keyword_case(self, *, formatted_output: str) -> str:
+        """Apply the configured casing to keywords in formatted output.
+
+        Parameters:
+        ----------
+        formatted_output: str
+            Formatted output.
+
+        Returns:
+        -------
+        str
+            Formatted output with keyword casing applied.
+        """
+        if self.config.format.uppercase_keywords:
+            return formatted_output
+
+        output = list(formatted_output)
+        for token in parser.scan(formatted_output):
+            if token.kind != "NO_KEYWORD":
+                output[token.start : token.end + 1] = formatted_output[
+                    token.start : token.end + 1
+                ].lower()
+
+        return "".join(output)
+
     def _concatenate_nodes(
         self,
         *,
@@ -138,14 +163,17 @@ class Formatter:
                 try:
                     parser.parse_sql(statement.text)
 
-                    formatted_statement = IndentedStream(
+                    output = IndentedStream(
                         config=config,
                         comments=comments,
                         semicolon_after_last_statement=False,
                         remove_pg_catalog_from_functions=config.format.remove_pg_catalog_from_functions,
                         comma_at_eoln=not (config.format.comma_at_beginning),
                         special_functions=True,
-                    )(statement.text)
+                    )
+                    formatted_statement = output.apply_keyword_case(
+                        formatted_output=output(statement.text),
+                    )
 
                     if config.format.new_line_before_semicolon:
                         formatted_statement += noqa.NEW_LINE + noqa.SEMI_COLON
@@ -216,3 +244,32 @@ class Formatter:
             formatted_source_code=formatted_source_code,
             errors=errors,
         )
+
+    def format_ast(
+        self,
+        *,
+        source_ast: ast.Node | tuple[ast.RawStmt, ...],
+        comments: list[noqa.Comment],
+    ) -> str:
+        """Format source code from AST.
+
+        Parameters:
+        ----------
+        source_ast: ast.Node
+            Source AST to format.
+
+        Returns:
+        -------
+        str
+            Formatted source code.
+        """
+        output = IndentedStream(
+            config=self.config,
+            comments=comments,
+            semicolon_after_last_statement=False,
+            separate_statements=self.config.format.lines_between_statements,
+            remove_pg_catalog_from_functions=self.config.format.remove_pg_catalog_from_functions,
+            comma_at_eoln=not (self.config.format.comma_at_beginning),
+            special_functions=True,
+        )
+        return output.apply_keyword_case(formatted_output=output(source_ast))

--- a/src/pgrubic/core/formatter.py
+++ b/src/pgrubic/core/formatter.py
@@ -25,13 +25,13 @@ class IndentedStream(stream.IndentedStream):
         super().__init__(**options)
         self.config = config
 
-    def apply_keyword_case(self, *, formatted_output: str) -> str:
+    def apply_keyword_case(self, *, text: str) -> str:
         """Apply the configured casing to keywords in formatted output.
 
         Parameters:
         ----------
-        formatted_output: str
-            Formatted output.
+        text: str
+            Text to apply keyword casing to.
 
         Returns:
         -------
@@ -39,12 +39,12 @@ class IndentedStream(stream.IndentedStream):
             Formatted output with keyword casing applied.
         """
         if self.config.format.uppercase_keywords:
-            return formatted_output
+            return text
 
-        output = list(formatted_output)
-        for token in parser.scan(formatted_output):
+        output = list(text)
+        for token in parser.scan(text):
             if token.kind != "NO_KEYWORD":
-                output[token.start : token.end + 1] = formatted_output[
+                output[token.start : token.end + 1] = text[
                     token.start : token.end + 1
                 ].lower()
 
@@ -172,7 +172,7 @@ class Formatter:
                         special_functions=True,
                     )
                     formatted_statement = output.apply_keyword_case(
-                        formatted_output=output(statement.text),
+                        text=output(statement.text),
                     )
 
                     if config.format.new_line_before_semicolon:
@@ -272,4 +272,4 @@ class Formatter:
             comma_at_eoln=not (self.config.format.comma_at_beginning),
             special_functions=True,
         )
-        return output.apply_keyword_case(formatted_output=output(source_ast))
+        return output.apply_keyword_case(text=output(source_ast))

--- a/src/pgrubic/core/formatter.py
+++ b/src/pgrubic/core/formatter.py
@@ -248,15 +248,17 @@ class Formatter:
     def format_ast(
         self,
         *,
-        source_ast: ast.Node | tuple[ast.RawStmt, ...],
+        source_ast: tuple[ast.RawStmt, ...],
         comments: list[noqa.Comment],
     ) -> str:
         """Format source code from AST.
 
         Parameters:
         ----------
-        source_ast: ast.Node
+        source_ast: tuple[ast.RawStmt, ...]
             Source AST to format.
+        comments: list[noqa.Comment]
+            Comments extracted from the original statement.
 
         Returns:
         -------

--- a/src/pgrubic/core/formatter.py
+++ b/src/pgrubic/core/formatter.py
@@ -26,7 +26,7 @@ class IndentedStream(stream.IndentedStream):
         self.config = config
 
     def apply_keyword_case(self, *, text: str) -> str:
-        """Apply the configured casing to keywords in formatted output.
+        """Apply the configured casing to keywords in the given text.
 
         Parameters:
         ----------

--- a/src/pgrubic/core/linter.py
+++ b/src/pgrubic/core/linter.py
@@ -634,18 +634,13 @@ class Linter:
                 violations.update(checker.violations)
 
             # If the statement parse tree has been modified due to fixes,
-            # we convert it to string
+            # we output the fixed statement, otherwise we output the original statement
             if BaseChecker.statement_fixes.counter > 0:
                 try:
-                    fixed_statement = formatter.IndentedStream(
-                        config=self.config,
+                    fixed_statement = self.formatter.format_ast(
+                        source_ast=parse_tree,
                         comments=comments,
-                        semicolon_after_last_statement=False,
-                        special_functions=True,
-                        separate_statements=self.config.format.lines_between_statements,
-                        remove_pg_catalog_from_functions=self.config.format.remove_pg_catalog_from_functions,
-                        comma_at_eoln=not (self.config.format.comma_at_beginning),
-                    )(parse_tree)
+                    )
 
                     if self.config.format.new_line_before_semicolon:
                         fixed_statement += noqa.NEW_LINE + noqa.SEMI_COLON

--- a/src/pgrubic/pgrubic.toml
+++ b/src/pgrubic/pgrubic.toml
@@ -34,6 +34,7 @@ include = []
 exclude = []
 comma-at-beginning = true
 compact-parenthesized-lists-margin = 90
+uppercase-keywords = true
 new-line-before-semicolon = false
 remove-pg-catalog-from-functions = true
 remove-default-index-access-method = true

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -35,6 +35,7 @@ def test_config_from_current_working_directory(tmp_path: pathlib.Path) -> None:
     [format]
     diff = true
     compact-parenthesized-lists-margin = 100
+    uppercase-keywords = false
     """
     directory = tmp_path / "sub"
     directory.mkdir()
@@ -47,6 +48,7 @@ def test_config_from_current_working_directory(tmp_path: pathlib.Path) -> None:
 
         parsed_config = config.parse_config()
         assert parsed_config.format.diff is True
+        assert parsed_config.format.uppercase_keywords is False
         assert (
             parsed_config.format.compact_parenthesized_lists_margin
             == expected_compact_parenthesized_lists_margin

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -88,6 +88,8 @@ select foo as "FROM"
    and name ilike '%postgres%';
 """
 
+    current_uppercase_keywords = formatter.config.format.uppercase_keywords
+
     formatter.config.format.uppercase_keywords = False
 
     result = formatter.format(
@@ -95,23 +97,6 @@ select foo as "FROM"
         source_code=source_code,
     )
 
-    assert result.formatted_source_code == expected_output
-
-    formatter.config.format.uppercase_keywords = True
-
-
-def test_uppercase_keywords_includes_postgresql_keywords(
-    formatter: core.Formatter,
-) -> None:
-    """Test uppercase formatting includes PostgreSQL-specific keywords."""
-    source_code = "select name ilike '%postgres%' from projects;"
-    expected_output = "SELECT name ILIKE '%postgres%'\n  FROM projects;\n"
-
-    formatter.config.format.uppercase_keywords = True
-
-    result = formatter.format(
-        source_file=TEST_FILE,
-        source_code=source_code,
-    )
+    formatter.config.format.uppercase_keywords = current_uppercase_keywords
 
     assert result.formatted_source_code == expected_output

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -70,22 +70,44 @@ def test_new_line_before_semicolon(formatter: core.Formatter) -> None:
     )
 
     assert result.formatted_source_code == expected_output
+    formatter.config.format.new_line_before_semicolon = False
 
 
 def test_lowercase_keywords_preserves_other_tokens(formatter: core.Formatter) -> None:
     """Test lowercase keywords preserve other SQL token values."""
-    source_code = (
-        "SELECT Foo AS \"FROM\", 'WHERE' FROM Café -- JOIN\nWHERE Foo::TEXT IS NOT NULL;"
-    )
-    expected_output = (
-        '-- JOIN\nselect foo as "FROM"\n'
-        "     , 'WHERE'\n"
-        '  from "café"\n'
-        " where cast(foo as text) is not null;\n"
-    )
+    source_code = """
+SELECT Foo AS "FROM", 'WHERE' FROM Café -- JOIN
+WHERE Foo::TEXT IS NOT NULL and name ILIKE '%postgres%';
+"""
+
+    expected_output = """-- JOIN
+select foo as "FROM"
+     , 'WHERE'
+  from "café"
+ where cast(foo as text) is not null
+   and name ilike '%postgres%';
+"""
 
     formatter.config.format.uppercase_keywords = False
-    formatter.config.format.new_line_before_semicolon = False
+
+    result = formatter.format(
+        source_file=TEST_FILE,
+        source_code=source_code,
+    )
+
+    assert result.formatted_source_code == expected_output
+
+    formatter.config.format.uppercase_keywords = True
+
+
+def test_uppercase_keywords_includes_postgresql_keywords(
+    formatter: core.Formatter,
+) -> None:
+    """Test uppercase formatting includes PostgreSQL-specific keywords."""
+    source_code = "select name ilike '%postgres%' from projects;"
+    expected_output = "SELECT name ILIKE '%postgres%'\n  FROM projects;\n"
+
+    formatter.config.format.uppercase_keywords = True
 
     result = formatter.format(
         source_file=TEST_FILE,

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -62,15 +62,17 @@ def test_new_line_before_semicolon(formatter: core.Formatter) -> None:
     source_code = "select 1;"
     expected_output: str = f"SELECT 1{noqa.NEW_LINE};{noqa.NEW_LINE}"
 
+    current_new_line_before_semicolon = formatter.config.format.new_line_before_semicolon
+
     formatter.config.format.new_line_before_semicolon = True
 
     result = formatter.format(
         source_file=TEST_FILE,
         source_code=source_code,
     )
+    formatter.config.format.new_line_before_semicolon = current_new_line_before_semicolon
 
     assert result.formatted_source_code == expected_output
-    formatter.config.format.new_line_before_semicolon = False
 
 
 def test_lowercase_keywords_preserves_other_tokens(formatter: core.Formatter) -> None:

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -70,3 +70,26 @@ def test_new_line_before_semicolon(formatter: core.Formatter) -> None:
     )
 
     assert result.formatted_source_code == expected_output
+
+
+def test_lowercase_keywords_preserves_other_tokens(formatter: core.Formatter) -> None:
+    """Test lowercase keywords preserve other SQL token values."""
+    source_code = (
+        "SELECT Foo AS \"FROM\", 'WHERE' FROM Café -- JOIN\nWHERE Foo::TEXT IS NOT NULL;"
+    )
+    expected_output = (
+        '-- JOIN\nselect foo as "FROM"\n'
+        "     , 'WHERE'\n"
+        '  from "café"\n'
+        " where cast(foo as text) is not null;\n"
+    )
+
+    formatter.config.format.uppercase_keywords = False
+    formatter.config.format.new_line_before_semicolon = False
+
+    result = formatter.format(
+        source_file=TEST_FILE,
+        source_code=source_code,
+    )
+
+    assert result.formatted_source_code == expected_output


### PR DESCRIPTION
## Background and Motivation
<!-- Why is this change needed? What problem does it solve? -->
Pgrubic currently emits SQL keywords in uppercase unconditionally. While uppercase keywords are a common convention, many projects prefer lowercase SQL and should be able to enforce that style consistently.
This change introduces an uppercase-keywords formatting option. Uppercase remains the default for backward compatibility, while users can opt into lowercase keywords without affecting identifiers, quoted identifiers, string literals, comments, or other SQL content.
Keyword conversion uses PostgreSQL’s scanner instead of general string replacement. This ensures PostgreSQL-specific keywords are recognized and only genuine keyword tokens have their casing changed.

## Summary of Changes
<!-- High-level overview of what was changed. -->
- Adds the [format] uppercase-keywords configuration option.
- Defaults uppercase-keywords to true, preserving existing output.
- Formats keywords in lowercase when uppercase-keywords = false.
- Adds a reusable IndentedStream.apply_keyword_case() method for applying the configured keyword style.
- Applies keyword casing to regular formatter output and statements regenerated from ASTs during automatic lint fixes.
- Uses PostgreSQL tokenization to preserve:
   - Identifiers and quoted identifiers
   - String literals
   - Comments
   - Unicode content
- Adds coverage for uppercase and lowercase formatting, including the PostgreSQL-specific e.g ILIKE keyword.
- Updates the configuration model, default configuration, tests, and generated settings documentation.

## Type of change
<!-- Select the type of change. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Housekeeping (change that does not affect functionality)

## SQL Examples (if applicable)
<!-- Provide sample SQL to show before/after behavior of the linter/formatter. -->

```sql
-- Before
SELECT foo AS "FROM"
     , 'WHERE'
  FROM "café"
 WHERE CAST(foo AS text) IS NOT NULL
   AND name ILIKE '%postgres%';

-- After with uppercase-keywords = false
select foo as "FROM"
     , 'WHERE'
  from "café"
 where cast(foo as text) is not null
   and name ilike '%postgres%';
```

## Checklist
<!-- Checklist before requesting a review -->
- [x] I have read and followed the [contributing guidelines](https://github.com/bolajiwahab/pgrubic/blob/main/docs/docs/contributing.md)
- [x] I have checked that there are no other open [Pull Requests](https://github.com/bolajiwahab/pgrubic/pulls) for the same update/change
- [x] I have performed a self-review of my code
- [x] I have added/updated tests (positive + negative cases)
- [x] I have updated documentation (if applicable)

## Closes / Fixes
<!-- Link issues using keywords: Closes #123, Fixes #456 -->

## Additional information
<!-- Provide any additional information that might be helpful to the reviewer in reviewing this pull request -->
