### PR TITLE
test: Isolate temporary configuration overrides in formatter and rule tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -143,6 +143,7 @@ def _restore_config(*, config: typing.Any, previous_config: typing.Any) -> None:
 
 @contextlib.contextmanager
 def update_config(
+    *,
     config: core.Config,
     overrides: dict[str, typing.Any],
 ) -> typing.Iterator[None]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,11 @@
 """Conftest."""
 
+import copy
 import enum
 import typing
 import pathlib
+import contextlib
+import dataclasses
 
 import yaml
 import pytest
@@ -83,13 +86,12 @@ def load_test_cases(
     return test_cases
 
 
-def update_config(config: core.Config, overrides: dict[str, typing.Any]) -> None:
-    """Update config object with overrides."""
+def _update_config(*, config: typing.Any, overrides: dict[str, typing.Any]) -> None:
+    """Update a config object with overrides."""
     for key, value in overrides.items():
         if isinstance(value, dict):
             # If value is a dictionary, recursively update the nested config attribute
-            sub_config = getattr(config, key)
-            update_config(sub_config, value)
+            _update_config(config=getattr(config, key), overrides=value)
         elif key == "required_columns":
             # Ensure required_columns is a list of columns
             setattr(
@@ -131,3 +133,23 @@ def update_config(config: core.Config, overrides: dict[str, typing.Any]) -> None
         else:
             # Set the attribute directly, e.g., config.format.lines_between_statements = 1
             setattr(config, key, value)
+
+
+def _restore_config(*, config: typing.Any, previous_config: typing.Any) -> None:
+    """Restore a config snapshot while preserving the root object."""
+    for field in dataclasses.fields(config):
+        setattr(config, field.name, getattr(previous_config, field.name))
+
+
+@contextlib.contextmanager
+def update_config(
+    config: core.Config,
+    overrides: dict[str, typing.Any],
+) -> typing.Iterator[None]:
+    """Temporarily update a config object with overrides."""
+    previous_config = copy.deepcopy(config)
+    try:
+        _update_config(config=config, overrides=overrides)
+        yield
+    finally:
+        _restore_config(config=config, previous_config=previous_config)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -77,7 +77,7 @@ def test_update_config_restores_previous_values() -> None:
             parsed_config.format.compact_parenthesized_lists_margin
             == new_compact_parenthesized_lists_margin
         )
-        assert parsed_config.lint.fix
+        assert parsed_config.lint.fix == (not previous_fix)
 
     assert parsed_config.format.compact_parenthesized_lists_margin == previous_margin
     assert parsed_config.lint.fix is previous_fix

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 
 import pytest
 
+from tests import conftest
 from pgrubic.core import config, errors
 
 
@@ -53,6 +54,33 @@ def test_config_from_current_working_directory(tmp_path: pathlib.Path) -> None:
             parsed_config.format.compact_parenthesized_lists_margin
             == expected_compact_parenthesized_lists_margin
         )
+
+
+def test_update_config_restores_previous_values() -> None:
+    """Test temporary config overrides are restored on context exit."""
+    parsed_config = config.parse_config()
+    previous_margin = parsed_config.format.compact_parenthesized_lists_margin
+    previous_fix = parsed_config.lint.fix
+
+    new_compact_parenthesized_lists_margin = 20
+
+    with conftest.update_config(
+        parsed_config,
+        {
+            "format": {
+                "compact_parenthesized_lists_margin": new_compact_parenthesized_lists_margin,  # noqa: E501
+            },
+            "lint": {"fix": not previous_fix},
+        },
+    ):
+        assert (
+            parsed_config.format.compact_parenthesized_lists_margin
+            == new_compact_parenthesized_lists_margin
+        )
+        assert parsed_config.lint.fix
+
+    assert parsed_config.format.compact_parenthesized_lists_margin == previous_margin
+    assert parsed_config.lint.fix is previous_fix
 
 
 def test_missing_config_error(tmp_path: pathlib.Path) -> None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -65,8 +65,8 @@ def test_update_config_restores_previous_values() -> None:
     new_compact_parenthesized_lists_margin = 20
 
     with conftest.update_config(
-        parsed_config,
-        {
+        config=parsed_config,
+        overrides={
             "format": {
                 "compact_parenthesized_lists_margin": new_compact_parenthesized_lists_margin,  # noqa: E501
             },

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -30,7 +30,7 @@ def test_formatters(
         test_case.get("config", {}),
     )
 
-    with conftest.update_config(formatter.config, config_overrides):
+    with conftest.update_config(config=formatter.config, overrides=config_overrides):
         result = formatter.format(
             source_file=TEST_FILE,
             source_code=test_case["sql"],
@@ -61,8 +61,8 @@ def test_new_line_before_semicolon(formatter: core.Formatter) -> None:
     expected_output: str = f"SELECT 1{noqa.NEW_LINE};{noqa.NEW_LINE}"
 
     with conftest.update_config(
-        formatter.config,
-        {"format": {"new_line_before_semicolon": True}},
+        config=formatter.config,
+        overrides={"format": {"new_line_before_semicolon": True}},
     ):
         result = formatter.format(
             source_file=TEST_FILE,
@@ -88,8 +88,8 @@ select foo as "FROM"
 """
 
     with conftest.update_config(
-        formatter.config,
-        {"format": {"uppercase_keywords": False}},
+        config=formatter.config,
+        overrides={"format": {"uppercase_keywords": False}},
     ):
         result = formatter.format(
             source_file=TEST_FILE,

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -30,24 +30,22 @@ def test_formatters(
         test_case.get("config", {}),
     )
 
-    # Apply overrides to global configuration
-    conftest.update_config(formatter.config, config_overrides)
+    with conftest.update_config(formatter.config, config_overrides):
+        result = formatter.format(
+            source_file=TEST_FILE,
+            source_code=test_case["sql"],
+        )
 
-    result = formatter.format(
-        source_file=TEST_FILE,
-        source_code=test_case["sql"],
-    )
+        assert result.formatted_source_code == test_case["expected"], (
+            f"Test failed for formatter: `{test_formatter}` in `{test_id}`"
+        )
 
-    assert result.formatted_source_code == test_case["expected"], (
-        f"Test failed for formatter: `{test_formatter}` in `{test_id}`"
-    )
-
-    # Check that the formatted source code is valid
-    try:
-        parser.parse_sql(result.formatted_source_code)
-    except parser.ParseError as error:
-        msg = f"Formatted code is not a valid syntax: {error!s}"
-        raise ValueError(msg) from error
+        # Check that the formatted source code is valid
+        try:
+            parser.parse_sql(result.formatted_source_code)
+        except parser.ParseError as error:
+            msg = f"Formatted code is not a valid syntax: {error!s}"
+            raise ValueError(msg) from error
 
 
 def test_format_parse_error(formatter: core.Formatter) -> None:
@@ -62,15 +60,14 @@ def test_new_line_before_semicolon(formatter: core.Formatter) -> None:
     source_code = "select 1;"
     expected_output: str = f"SELECT 1{noqa.NEW_LINE};{noqa.NEW_LINE}"
 
-    current_new_line_before_semicolon = formatter.config.format.new_line_before_semicolon
-
-    formatter.config.format.new_line_before_semicolon = True
-
-    result = formatter.format(
-        source_file=TEST_FILE,
-        source_code=source_code,
-    )
-    formatter.config.format.new_line_before_semicolon = current_new_line_before_semicolon
+    with conftest.update_config(
+        formatter.config,
+        {"format": {"new_line_before_semicolon": True}},
+    ):
+        result = formatter.format(
+            source_file=TEST_FILE,
+            source_code=source_code,
+        )
 
     assert result.formatted_source_code == expected_output
 
@@ -90,15 +87,13 @@ select foo as "FROM"
    and name ilike '%postgres%';
 """
 
-    current_uppercase_keywords = formatter.config.format.uppercase_keywords
-
-    formatter.config.format.uppercase_keywords = False
-
-    result = formatter.format(
-        source_file=TEST_FILE,
-        source_code=source_code,
-    )
-
-    formatter.config.format.uppercase_keywords = current_uppercase_keywords
+    with conftest.update_config(
+        formatter.config,
+        {"format": {"uppercase_keywords": False}},
+    ):
+        result = formatter.format(
+            source_file=TEST_FILE,
+            source_code=source_code,
+        )
 
     assert result.formatted_source_code == expected_output

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -45,44 +45,46 @@ def test_rules(
         test_case.get("config", {}),
     )
 
-    # Apply overrides to global configuration
-    conftest.update_config(linter.config, config_overrides)
+    with conftest.update_config(linter.config, config_overrides):
+        if parsed_test_case.sql_fail:
+            # Set fix flag
+            linter.config.lint.fix = bool(parsed_test_case.sql_fix)
 
-    if parsed_test_case.sql_fail:
-        # Set fix flag
-        linter.config.lint.fix = bool(parsed_test_case.sql_fix)
+            linting_result = linter.run(
+                source_file=f"{parsed_test_case.rule}.sql",
+                source_code=parsed_test_case.sql_fail,
+            )
 
-        linting_result = linter.run(
-            source_file=f"{parsed_test_case.rule}.sql",
-            source_code=parsed_test_case.sql_fail,
-        )
+            assert len(linting_result.errors) == 0, (
+                "Test failed: Errors found in test case"
+            )
 
-        assert len(linting_result.errors) == 0, "Test failed: Errors found in test case"
+            assert any(
+                violation.rule_code == rule for violation in linting_result.violations
+            ), f"Test failed: No violations found for rule: `{rule}` in `{test_id}`"
 
-        assert any(
-            violation.rule_code == rule for violation in linting_result.violations
-        ), f"Test failed: No violations found for rule: `{rule}` in `{test_id}`"
+            if parsed_test_case.sql_fix:
+                assert linting_result.fixed_source_code == parsed_test_case.sql_fix
 
-        if parsed_test_case.sql_fix:
-            assert linting_result.fixed_source_code == parsed_test_case.sql_fix
+                # Check that the fixed source_code is valid
+                try:
+                    parser.parse_sql(linting_result.fixed_source_code)
+                except parser.ParseError as error:
+                    msg = f"Formatted code is not a valid syntax: {error!s}"
+                    raise ValueError(msg) from error
 
-            # Check that the fixed source_code is valid
-            try:
-                parser.parse_sql(linting_result.fixed_source_code)
-            except parser.ParseError as error:
-                msg = f"Formatted code is not a valid syntax: {error!s}"
-                raise ValueError(msg) from error
+        if parsed_test_case.sql_pass:
+            linting_result = linter.run(
+                source_file=f"{parsed_test_case.rule}.sql",
+                source_code=parsed_test_case.sql_pass,
+            )
 
-    if parsed_test_case.sql_pass:
-        linting_result = linter.run(
-            source_file=f"{parsed_test_case.rule}.sql",
-            source_code=parsed_test_case.sql_pass,
-        )
+            assert len(linting_result.errors) == 0, (
+                "Test failed: Errors found in test case"
+            )
 
-        assert len(linting_result.errors) == 0, "Test failed: Errors found in test case"
-
-        assert not any(
-            violation.rule_code == rule for violation in linting_result.violations
-        ), (
-            f"""Test failed: Violations found for rule: `{rule}` in `{test_id}` which should pass"""  # noqa: E501
-        )
+            assert not any(
+                violation.rule_code == rule for violation in linting_result.violations
+            ), (
+                f"""Test failed: Violations found for rule: `{rule}` in `{test_id}` which should pass"""  # noqa: E501
+            )

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -45,7 +45,7 @@ def test_rules(
         test_case.get("config", {}),
     )
 
-    with conftest.update_config(linter.config, config_overrides):
+    with conftest.update_config(config=linter.config, overrides=config_overrides):
         if parsed_test_case.sql_fail:
             # Set fix flag
             linter.config.lint.fix = bool(parsed_test_case.sql_fix)


### PR DESCRIPTION
## Background and Motivation
<!-- Why is this change needed? What problem does it solve? -->
Formatter and rule tests share configuration objects through module- and session-scoped fixtures. The existing **update_config** helper mutated those objects without restoring their previous values, allowing one test case’s settings to leak into subsequent tests.
This made tests order-dependent and required individual tests to manually save and restore configuration values. It also meant a failed assertion could prevent cleanup and leave the shared fixture in an unexpected state.
This change makes configuration overrides temporary by applying them through a context manager and restoring the original configuration in a finally block.

## Summary of Changes
<!-- High-level overview of what was changed. -->
- Converts **update_config** into a context manager for temporary configuration overrides.
- Takes a deep snapshot of the configuration before applying overrides.
- Restores the previous top-level configuration fields when the context exits.
- Guarantees restoration when a test fails or raises an exception.
- Preserves the shared root Config object used by formatters, linters, and checkers.
- Retains recursive dictionary overrides for lint and format sections.
- Retains conversions for structured settings such as:
   - Required columns
   - Disallowed schemas
   - Disallowed data types

- Updates parameterized formatter and rule tests to use the context manager.
- Replaces manual save-and-restore logic in keyword-casing and semicolon tests.
- Adds regression coverage confirming overridden and incidental configuration changes are restored.

## Type of change
<!-- Select the type of change. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Housekeeping (change that does not affect functionality)

## SQL Examples (if applicable)
<!-- Provide sample SQL to show before/after behavior of the linter/formatter. -->

```sql
-- Before
...

-- After
...
```

## Checklist
<!-- Checklist before requesting a review -->
- [x] I have read and followed the [contributing guidelines](https://github.com/bolajiwahab/pgrubic/blob/main/docs/docs/contributing.md)
- [x] I have checked that there are no other open [Pull Requests](https://github.com/bolajiwahab/pgrubic/pulls) for the same update/change
- [x] I have performed a self-review of my code
- [x] I have added/updated tests (positive + negative cases)
- [ ] I have updated documentation (if applicable)

## Closes / Fixes
<!-- Link issues using keywords: Closes #123, Fixes #456 -->

## Additional information
<!-- Provide any additional information that might be helpful to the reviewer in reviewing this pull request -->
