### PR TITLE
feat:  make type casting configurable

### DIFF
--- a/docs/docs/settings.md
+++ b/docs/docs/settings.md
@@ -250,8 +250,8 @@ List of required columns along with their data types for every table.
 ```toml
 [lint]
 required-columns = [
-    { name = "created_at", data_type = "timestamptz" },
-    { name = "updated_at", data_type = "timestamptz" },
+    { name = "created_at", data-type = "timestamptz" },
+    { name = "updated_at", data-type = "timestamptz" },
 ]
 ```
 </details>
@@ -627,9 +627,10 @@ uppercase-keywords = false
 </details>
 
 ### **type-casting-style**
-The type-casting style to use. Can be one of `native` or `standard`.
+The type-casting style to use. Can be one of `native`, `standard` or `literal`.
 
-Native style uses `::type_name` while standard style uses `CAST(type_name AS type_name)`
+Native style uses `value::type_name`, standard style uses `CAST(value AS type_name)`
+and literal style uses `type_name value`.
 
 **Type**: `str`
 

--- a/docs/docs/settings.md
+++ b/docs/docs/settings.md
@@ -626,6 +626,25 @@ uppercase-keywords = false
 ```
 </details>
 
+### **type-casting-style**
+The type-casting style to use. Can be one of `native` or `standard`.
+
+Native style uses `::type_name` while standard style uses `CAST(type_name AS type_name)`
+
+**Type**: `str`
+
+**Default**: `standard`
+
+**Example**:
+<details open>
+<summary><strong>pgrubic.toml</strong></summary>
+
+```toml
+[format]
+type-casting-style = "native"
+```
+</details>
+
 ### **new-line-before-semicolon**
 If `true`, add a new line before each semicolon.
 

--- a/docs/docs/settings.md
+++ b/docs/docs/settings.md
@@ -632,6 +632,28 @@ The type-casting style to use. Can be one of `native`, `standard` or `literal`.
 Native style uses `value::type_name`, standard style uses `CAST(value AS type_name)`
 and literal style uses `type_name value`.
 
+!!! note
+    Literal style is applied only when the typed-literal syntax is semantically
+    equivalent. When a cast cannot be converted safely, such as an implicit-length
+    `char` cast or a cast of a non-string expression, its original standard or
+    native syntax is preserved.
+
+    For example, these casts can safely use literal syntax:
+
+    ```sql
+    CAST('xyz' AS text)    -> text 'xyz'
+    'xyz'::char(3)         -> char(3) 'xyz'
+    ```
+
+    These casts retain their original syntax:
+
+    ```sql
+    CAST('xyz' AS char)    -> CAST('xyz' AS char)
+    'xyz'::char            -> 'xyz'::char
+    1::text                -> 1::text
+    CAST(1 + 1 AS text)    -> CAST(1 + 1 AS text)
+    ```
+
 **Type**: `str`
 
 **Default**: `standard`

--- a/src/pgrubic/__main__.py
+++ b/src/pgrubic/__main__.py
@@ -110,6 +110,9 @@ def lint(  # noqa: C901, PLR0912, PLR0913, PLR0915
     except errors.MissingConfigError as error:
         sys.stderr.write(f"{error}{noqa.NEW_LINE}")
         sys.exit(1)
+    except errors.InvalidConfigValueError as error:
+        sys.stderr.write(f"{error}{noqa.NEW_LINE}")
+        sys.exit(1)
     except errors.ConfigParseError as error:
         sys.stderr.write(f"{error}{noqa.NEW_LINE}")
         sys.exit(1)
@@ -301,6 +304,9 @@ def format_sources(  # noqa: C901, PLR0912, PLR0913, PLR0915
     try:
         config = core.parse_config()
     except errors.MissingConfigError as error:
+        sys.stderr.write(f"{error}{noqa.NEW_LINE}")
+        sys.exit(1)
+    except errors.InvalidConfigValueError as error:
         sys.stderr.write(f"{error}{noqa.NEW_LINE}")
         sys.exit(1)
     except errors.ConfigParseError as error:

--- a/src/pgrubic/core/config.py
+++ b/src/pgrubic/core/config.py
@@ -2,6 +2,7 @@
 
 import os
 import typing
+import difflib
 import pathlib
 import dataclasses
 
@@ -9,7 +10,7 @@ import toml
 from deepmerge import always_merger
 
 from pgrubic import PACKAGE_NAME
-from pgrubic.core import errors
+from pgrubic.core import enums, errors
 from pgrubic.core.logger import logger
 
 CONFIG_FILE: typing.Final[str] = f"{PACKAGE_NAME}.toml"
@@ -234,8 +235,8 @@ List of required columns along with their data types for every table.
 ```toml
 [lint]
 required-columns = [
-    { name = "created_at", data_type = "timestamptz" },
-    { name = "updated_at", data_type = "timestamptz" },
+    { name = "created_at", data-type = "timestamptz" },
+    { name = "updated_at", data-type = "timestamptz" },
 ]
 ```
 </details>
@@ -643,6 +644,25 @@ uppercase-keywords = false
 ```
 </details>
 
+### **type-casting-style**
+The type-casting style to use. Can be one of `native` or `standard`.
+
+Native style uses `::type_name` while standard style uses `CAST(type_name AS type_name)`
+
+**Type**: `str`
+
+**Default**: `standard`
+
+**Example**:
+<details open>
+<summary><strong>pgrubic.toml</strong></summary>
+
+```toml
+[format]
+type-casting-style = "native"
+```
+</details>
+
 ### **new-line-before-semicolon**
 If `true`, add a new line before each semicolon.
 
@@ -800,6 +820,7 @@ no-cache = true
     comma_at_beginning: bool
     compact_parenthesized_lists_margin: int
     uppercase_keywords: bool
+    type_casting_style: enums.TypeCastingStyle
     new_line_before_semicolon: bool
     lines_between_statements: int
     remove_pg_catalog_from_functions: bool
@@ -997,6 +1018,27 @@ def _get_config_file_absolute_path(
     return None  # pragma: no cover
 
 
+def _parse_type_casting_style(value: object) -> enums.TypeCastingStyle:
+    """Parse the configured type-casting style."""
+    valid_values = tuple(style.value for style in enums.TypeCastingStyle)
+
+    if isinstance(value, str):
+        try:
+            return enums.TypeCastingStyle(value)
+        except ValueError:
+            suggestion = difflib.get_close_matches(value, valid_values, n=1)
+    else:
+        suggestion = []
+
+    msg = f'Invalid config value for key "format.type-casting-style": "{value}".'
+    if suggestion:
+        msg += f' Did you mean "{suggestion[0]}"?'
+    valid_values_str = ", ".join(f'"{v}"' for v in valid_values)
+    msg += f" Expected one of: {valid_values_str}"
+
+    raise errors.InvalidConfigValueError(msg) from None
+
+
 def parse_config(overrides: dict[str, typing.Any] | None = None) -> Config:
     """Parse config.
 
@@ -1014,6 +1056,8 @@ def parse_config(overrides: dict[str, typing.Any] | None = None) -> Config:
     ------
     MissingConfigError
         Raised when a config is missing.
+    InvalidConfigValueError
+        Raised when a config value is invalid.
     """
     if not overrides:
         overrides = {}
@@ -1085,6 +1129,9 @@ def parse_config(overrides: dict[str, typing.Any] | None = None) -> Config:
                     "compact-parenthesized-lists-margin"
                 ],
                 uppercase_keywords=config_format["uppercase-keywords"],
+                type_casting_style=_parse_type_casting_style(
+                    config_format["type-casting-style"],
+                ),
                 new_line_before_semicolon=config_format["new-line-before-semicolon"],
                 lines_between_statements=config_format["lines-between-statements"],
                 remove_pg_catalog_from_functions=config_format[

--- a/src/pgrubic/core/config.py
+++ b/src/pgrubic/core/config.py
@@ -1031,8 +1031,10 @@ def _parse_type_casting_style(value: object) -> enums.TypeCastingStyle:
         suggestion = []
 
     msg = f'Invalid config value for key "format.type-casting-style": "{value}".'
+
     if suggestion:
         msg += f' Did you mean "{suggestion[0]}"?'
+
     valid_values_str = ", ".join(f'"{v}"' for v in valid_values)
     msg += f" Expected one of: {valid_values_str}"
 

--- a/src/pgrubic/core/config.py
+++ b/src/pgrubic/core/config.py
@@ -645,9 +645,10 @@ uppercase-keywords = false
 </details>
 
 ### **type-casting-style**
-The type-casting style to use. Can be one of `native` or `standard`.
+The type-casting style to use. Can be one of `native`, `standard` or `literal`.
 
-Native style uses `::type_name` while standard style uses `CAST(type_name AS type_name)`
+Native style uses `value::type_name`, standard style uses `CAST(value AS type_name)`
+and literal style uses `type_name value`.
 
 **Type**: `str`
 

--- a/src/pgrubic/core/config.py
+++ b/src/pgrubic/core/config.py
@@ -650,6 +650,28 @@ The type-casting style to use. Can be one of `native`, `standard` or `literal`.
 Native style uses `value::type_name`, standard style uses `CAST(value AS type_name)`
 and literal style uses `type_name value`.
 
+!!! note
+    Literal style is applied only when the typed-literal syntax is semantically
+    equivalent. When a cast cannot be converted safely, such as an implicit-length
+    `char` cast or a cast of a non-string expression, its original standard or
+    native syntax is preserved.
+
+    For example, these casts can safely use literal syntax:
+
+    ```sql
+    CAST('xyz' AS text)    -> text 'xyz'
+    'xyz'::char(3)         -> char(3) 'xyz'
+    ```
+
+    These casts retain their original syntax:
+
+    ```sql
+    CAST('xyz' AS char)    -> CAST('xyz' AS char)
+    'xyz'::char            -> 'xyz'::char
+    1::text                -> 1::text
+    CAST(1 + 1 AS text)    -> CAST(1 + 1 AS text)
+    ```
+
 **Type**: `str`
 
 **Default**: `standard`

--- a/src/pgrubic/core/enums.py
+++ b/src/pgrubic/core/enums.py
@@ -9,3 +9,11 @@ class FunctionOption(enum.StrEnum):
     SECURITY = enum.auto()
     LANGUAGE = enum.auto()
     SET = enum.auto()
+
+
+class TypeCastingStyle(enum.StrEnum):
+    """Type-casting output style."""
+
+    NATIVE = enum.auto()
+    STANDARD = enum.auto()
+    LITERAL = enum.auto()

--- a/src/pgrubic/core/errors.py
+++ b/src/pgrubic/core/errors.py
@@ -16,6 +16,10 @@ class MissingConfigError(BaseError):
     """Raised when a config is missing."""
 
 
+class InvalidConfigValueError(BaseError):
+    """Raised when a config value is invalid."""
+
+
 class ConfigFileNotFoundError(BaseError):
     """Raised when a config file is not found."""
 

--- a/src/pgrubic/core/formatter.py
+++ b/src/pgrubic/core/formatter.py
@@ -20,19 +20,31 @@ class FormatResult(typing.NamedTuple):
 class RawStream(stream.RawStream):
     """Raw SQL parse tree writer."""
 
-    def __init__(self, config: config.Config, **options: object) -> None:
-        """Initialize RawStream with config."""
+    def __init__(
+        self,
+        config: config.Config,
+        source_code: str | None = None,
+        **options: object,
+    ) -> None:
+        """Extend RawStream with config."""
         super().__init__(**options)
         self.config = config
+        self.source_code = source_code
 
 
 class IndentedStream(stream.IndentedStream):
     """Indented SQL parse tree writer."""
 
-    def __init__(self, config: config.Config, **options: typing.Any) -> None:
+    def __init__(
+        self,
+        config: config.Config,
+        source_code: str | None = None,
+        **options: object,
+    ) -> None:
         """Initialize IndentedStream with config."""
         super().__init__(**options)
         self.config = config
+        self.source_code = source_code
 
     def apply_keyword_case(self, *, text: str) -> str:
         """Apply the configured casing to keywords in the given text.
@@ -69,16 +81,18 @@ class IndentedStream(stream.IndentedStream):
         """Concatenate the given `nodes`, using `sep` as the separator."""
         output = RawStream(
             config=self.config,
+            source_code=self.source_code,
             special_functions=self.special_functions,
-            comma_at_eoln=self.comma_at_eoln,
             remove_pg_catalog_from_functions=self.remove_pg_catalog_from_functions,
         )
+
         output.print_list(
             nodes=nodes,
             sep=sep,
             standalone_items=False,
             are_names=are_names,
         )
+
         return output.getvalue()
 
     def write_empty_space(self) -> None:
@@ -181,6 +195,7 @@ class Formatter:
 
                     output = IndentedStream(
                         config=config,
+                        source_code=statement.text,
                         comments=comments,
                         semicolon_after_last_statement=False,
                         remove_pg_catalog_from_functions=config.format.remove_pg_catalog_from_functions,
@@ -265,6 +280,7 @@ class Formatter:
         self,
         *,
         source_ast: tuple[ast.RawStmt, ...],
+        source_code: str | None = None,
         comments: list[noqa.Comment],
     ) -> str:
         """Format source code from AST.
@@ -273,6 +289,8 @@ class Formatter:
         ----------
         source_ast: tuple[ast.RawStmt, ...]
             Source AST to format.
+        source_code: str | None
+            Original source code associated with the AST.
         comments: list[noqa.Comment]
             Comments extracted from the original statement.
 
@@ -283,6 +301,7 @@ class Formatter:
         """
         output = IndentedStream(
             config=self.config,
+            source_code=source_code,
             comments=comments,
             semicolon_after_last_statement=False,
             separate_statements=self.config.format.lines_between_statements,

--- a/src/pgrubic/core/formatter.py
+++ b/src/pgrubic/core/formatter.py
@@ -17,6 +17,15 @@ class FormatResult(typing.NamedTuple):
     errors: set[errors.Error]
 
 
+class RawStream(stream.RawStream):
+    """Raw SQL parse tree writer."""
+
+    def __init__(self, config: config.Config, **options: object) -> None:
+        """Initialize RawStream with config."""
+        super().__init__(**options)
+        self.config = config
+
+
 class IndentedStream(stream.IndentedStream):
     """Indented SQL parse tree writer."""
 
@@ -58,7 +67,8 @@ class IndentedStream(stream.IndentedStream):
         are_names: bool = False,
     ) -> str:
         """Concatenate the given `nodes`, using `sep` as the separator."""
-        output = stream.RawStream(
+        output = RawStream(
+            config=self.config,
             special_functions=self.special_functions,
             comma_at_eoln=self.comma_at_eoln,
             remove_pg_catalog_from_functions=self.remove_pg_catalog_from_functions,

--- a/src/pgrubic/core/linter.py
+++ b/src/pgrubic/core/linter.py
@@ -639,6 +639,7 @@ class Linter:
                 try:
                     fixed_statement = self.formatter.format_ast(
                         source_ast=parse_tree,
+                        source_code=statement.text,
                         comments=comments,
                     )
 

--- a/src/pgrubic/formatters/dml/typecast.py
+++ b/src/pgrubic/formatters/dml/typecast.py
@@ -35,29 +35,20 @@ def is_native_cast(
 ) -> bool:
     """Check whether a cast originated from PostgreSQL's ``::`` syntax."""
     native_cast_operator_length = len(NATIVE_CAST_OPERATOR)
-    if output.source_code is not None and node.location is not None:
-        return (
-            output.source_code[
-                node.location : node.location + native_cast_operator_length
-            ]
-            == NATIVE_CAST_OPERATOR
-        )
-
     return (
-        node.location is not None
-        and node.typeName.location is not None
-        and node.typeName.location == node.location + native_cast_operator_length
+        output.source_code is not None
+        and node.location is not None
+        and output.source_code[
+            node.location : node.location + native_cast_operator_length
+        ]
+        == NATIVE_CAST_OPERATOR
     )
 
 
-def char_has_default_length(node: ast.TypeName) -> bool:
+def char_has_default_length(typmods: tuple[ast.Node, ...]) -> bool:
     """Check whether a char type has the implicit default length of one."""
     default_char_length = 1
-    expected_typmod_count = 1
-    if not node.typmods or len(node.typmods) != expected_typmod_count:
-        return False
-
-    typmod = node.typmods[0]
+    typmod = typmods[0]
     return (
         isinstance(typmod, ast.A_Const)
         and isinstance(typmod.val, ast.Integer)
@@ -101,7 +92,11 @@ def type_cast(
         output.config.format.type_casting_style == enums.TypeCastingStyle.LITERAL
         and is_string_constant(node.arg)
         and (
-            not is_char_type(node.typeName) or not char_has_default_length(node.typeName)
+            not is_char_type(node.typeName)
+            or (
+                node.typeName.typmods is not None
+                and not char_has_default_length(node.typeName.typmods)
+            )
         )
     ):
         output.print_node(node.typeName)

--- a/src/pgrubic/formatters/dml/typecast.py
+++ b/src/pgrubic/formatters/dml/typecast.py
@@ -8,11 +8,23 @@ from pgrubic.core import enums, formatter
 NATIVE_CAST_OPERATOR = "::"
 
 
-def native_cast_argument_needs_parentheses(node: ast.Node) -> bool:
+def native_cast_argument_needs_parentheses(
+    node: ast.Node,
+    output: formatter.RawStream | formatter.IndentedStream,
+) -> bool:
     """Check whether a native cast argument needs parentheses."""
-    return isinstance(
+    if isinstance(node, ast.FuncCall):
+        function_name = get_fully_qualified_name(node.funcname)
+        return output.get_printer_for_function(function_name, node) is not None
+
+    return not isinstance(
         node,
-        ast.A_Expr | ast.BoolExpr | ast.BooleanTest | ast.NullTest,
+        ast.A_ArrayExpr
+        | ast.A_Const
+        | ast.A_Indirection
+        | ast.ColumnRef
+        | ast.ParamRef
+        | ast.TypeCast,
     )
 
 
@@ -80,7 +92,7 @@ def type_cast(
 
     if output.config.format.type_casting_style == enums.TypeCastingStyle.NATIVE:
         with output.expression(
-            need_parens=native_cast_argument_needs_parentheses(node.arg),
+            need_parens=native_cast_argument_needs_parentheses(node.arg, output),
         ):
             output.print_node(node.arg)
 
@@ -109,7 +121,7 @@ def type_cast(
         and is_native_cast(node, output)
     ):
         with output.expression(
-            need_parens=native_cast_argument_needs_parentheses(node.arg),
+            need_parens=native_cast_argument_needs_parentheses(node.arg, output),
         ):
             output.print_node(node.arg)
         output.write(NATIVE_CAST_OPERATOR)

--- a/src/pgrubic/formatters/dml/typecast.py
+++ b/src/pgrubic/formatters/dml/typecast.py
@@ -1,0 +1,62 @@
+"""Formatter for type casting."""
+
+from pglast import ast, printers
+
+from pgrubic import get_fully_qualified_name
+from pgrubic.core import enums, formatter
+
+
+def native_cast_argument_needs_parentheses(node: ast.Node) -> bool:
+    """Check whether a native cast argument needs parentheses."""
+    return isinstance(node, ast.A_Expr | ast.BoolExpr)
+
+
+def is_string_constant(node: ast.Node) -> bool:
+    """Check whether a node is a string constant usable as a typed literal."""
+    return isinstance(node, ast.A_Const) and isinstance(node.val, ast.String)
+
+
+@printers.node_printer(ast.TypeCast, override=True)
+def type_cast(
+    node: ast.TypeCast,
+    output: formatter.RawStream,
+) -> None:
+    """Printer for TypeCast."""
+    if (
+        is_string_constant(node.arg)
+        and isinstance(node.typeName, ast.TypeName)
+        and get_fully_qualified_name(node.typeName.names)
+        == "pg_catalog.bpchar"  # internal representation of char type
+        and node.typeName.typmods is None
+    ):
+        output.write("char")
+        output.space()
+        output.print_node(node.arg)
+        return
+
+    if output.config.format.type_casting_style == enums.TypeCastingStyle.NATIVE:
+        with output.expression(
+            need_parens=native_cast_argument_needs_parentheses(node.arg),
+        ):
+            output.print_node(node.arg)
+
+        output.write("::")
+        output.print_node(node.typeName)
+        return
+
+    if (
+        output.config.format.type_casting_style == enums.TypeCastingStyle.LITERAL
+        and is_string_constant(node.arg)
+    ):
+        output.print_node(node.typeName)
+        output.space()
+        output.print_node(node.arg)
+        return
+
+    output.write("CAST")
+    with output.expression(need_parens=True):
+        output.print_node(node.arg)
+        output.space()
+        output.write("AS")
+        output.space()
+        output.print_node(node.typeName)

--- a/src/pgrubic/formatters/dml/typecast.py
+++ b/src/pgrubic/formatters/dml/typecast.py
@@ -5,10 +5,15 @@ from pglast import ast, printers
 from pgrubic import get_fully_qualified_name
 from pgrubic.core import enums, formatter
 
+NATIVE_CAST_OPERATOR = "::"
+
 
 def native_cast_argument_needs_parentheses(node: ast.Node) -> bool:
     """Check whether a native cast argument needs parentheses."""
-    return isinstance(node, ast.A_Expr | ast.BoolExpr)
+    return isinstance(
+        node,
+        ast.A_Expr | ast.BoolExpr | ast.BooleanTest | ast.NullTest,
+    )
 
 
 def is_string_constant(node: ast.Node) -> bool:
@@ -16,17 +21,65 @@ def is_string_constant(node: ast.Node) -> bool:
     return isinstance(node, ast.A_Const) and isinstance(node.val, ast.String)
 
 
+def is_char_type(node: ast.Node) -> bool:
+    """Check whether a node is PostgreSQL's internal char type."""
+    return (
+        isinstance(node, ast.TypeName)
+        and get_fully_qualified_name(node.names) == "pg_catalog.bpchar"
+    )
+
+
+def is_native_cast(
+    node: ast.TypeCast,
+    output: formatter.RawStream | formatter.IndentedStream,
+) -> bool:
+    """Check whether a cast originated from PostgreSQL's ``::`` syntax."""
+    native_cast_operator_length = len(NATIVE_CAST_OPERATOR)
+    if output.source_code is not None and node.location is not None:
+        return (
+            output.source_code[
+                node.location : node.location + native_cast_operator_length
+            ]
+            == NATIVE_CAST_OPERATOR
+        )
+
+    return (
+        node.location is not None
+        and node.typeName.location is not None
+        and node.typeName.location == node.location + native_cast_operator_length
+    )
+
+
+def char_has_default_length(node: ast.TypeName) -> bool:
+    """Check whether a char type has the implicit default length of one."""
+    default_char_length = 1
+    expected_typmod_count = 1
+    if not node.typmods or len(node.typmods) != expected_typmod_count:
+        return False
+
+    typmod = node.typmods[0]
+    return (
+        isinstance(typmod, ast.A_Const)
+        and isinstance(typmod.val, ast.Integer)
+        and typmod.val.ival == default_char_length
+    )
+
+
 @printers.node_printer(ast.TypeCast, override=True)
 def type_cast(
     node: ast.TypeCast,
-    output: formatter.RawStream,
+    output: formatter.RawStream | formatter.IndentedStream,
 ) -> None:
     """Printer for TypeCast."""
+    # An unmodified CHAR typed literal is not interchangeable with an implicit
+    # char cast: CHAR 'xyz' retains all three characters, while both
+    # CAST('xyz' AS char) and 'xyz'::char mean char(1). PostgreSQL represents
+    # the typed literal with typmods=None, so preserve that form and only
+    # convert other char casts to literal syntax when they have a safe,
+    # explicit non-default length.
     if (
         is_string_constant(node.arg)
-        and isinstance(node.typeName, ast.TypeName)
-        and get_fully_qualified_name(node.typeName.names)
-        == "pg_catalog.bpchar"  # internal representation of char type
+        and is_char_type(node.typeName)
         and node.typeName.typmods is None
     ):
         output.write("char")
@@ -40,17 +93,32 @@ def type_cast(
         ):
             output.print_node(node.arg)
 
-        output.write("::")
+        output.write(NATIVE_CAST_OPERATOR)
         output.print_node(node.typeName)
         return
 
     if (
         output.config.format.type_casting_style == enums.TypeCastingStyle.LITERAL
         and is_string_constant(node.arg)
+        and (
+            not is_char_type(node.typeName) or not char_has_default_length(node.typeName)
+        )
     ):
         output.print_node(node.typeName)
         output.space()
         output.print_node(node.arg)
+        return
+
+    if (
+        output.config.format.type_casting_style == enums.TypeCastingStyle.LITERAL
+        and is_native_cast(node, output)
+    ):
+        with output.expression(
+            need_parens=native_cast_argument_needs_parentheses(node.arg),
+        ):
+            output.print_node(node.arg)
+        output.write(NATIVE_CAST_OPERATOR)
+        output.print_node(node.typeName)
         return
 
     output.write("CAST")

--- a/src/pgrubic/pgrubic.toml
+++ b/src/pgrubic/pgrubic.toml
@@ -35,6 +35,7 @@ exclude = []
 comma-at-beginning = true
 compact-parenthesized-lists-margin = 90
 uppercase-keywords = true
+type-casting-style = "standard"
 new-line-before-semicolon = false
 remove-pg-catalog-from-functions = true
 remove-default-index-access-method = true

--- a/tests/fixtures/formatters/dml/typecast.yml
+++ b/tests/fixtures/formatters/dml/typecast.yml
@@ -182,6 +182,15 @@ typecast_native_to_literal:
     format:
       type_casting_style: literal
 
+typecast_native_non_string_to_literal:
+  sql: |
+    SELECT 1::text;
+  expected: |
+    SELECT 1::text;
+  config:
+    format:
+      type_casting_style: literal
+
 typecast_literal_to_literal:
   sql: |
     SELECT text '1';
@@ -209,11 +218,83 @@ typecast_literal_char_to_literal:
     format:
       type_casting_style: literal
 
+typecast_standard_char_to_literal:
+  sql: |
+    SELECT CAST('xyz' AS char);
+  expected: |
+    SELECT CAST('xyz' AS char);
+  config:
+    format:
+      type_casting_style: literal
+
+typecast_native_char_to_literal:
+  sql: |
+    SELECT 'xyz'::char;
+  expected: |
+    SELECT 'xyz'::char;
+  config:
+    format:
+      type_casting_style: literal
+
+typecast_standard_char_with_length_to_literal:
+  sql: |
+    SELECT CAST('xyz' AS char(3));
+  expected: |
+    SELECT char(3) 'xyz';
+  config:
+    format:
+      type_casting_style: literal
+
+typecast_native_char_with_length_to_literal:
+  sql: |
+    SELECT 'xyz'::char(3);
+  expected: |
+    SELECT char(3) 'xyz';
+  config:
+    format:
+      type_casting_style: literal
+
 typecast_standard_expression_to_literal:
   sql: |
     SELECT CAST(1 + 1 AS text);
   expected: |
     SELECT CAST(1 + 1 AS text);
+  config:
+    format:
+      type_casting_style: literal
+
+typecast_native_expression_to_literal:
+  sql: |
+    SELECT (1 + 1)::text;
+  expected: |
+    SELECT (1 + 1)::text;
+  config:
+    format:
+      type_casting_style: literal
+
+typecast_native_null_test_to_native:
+  sql: |
+    SELECT CAST(value IS NULL AS text);
+  expected: |
+    SELECT (value IS NULL)::text;
+  config:
+    format:
+      type_casting_style: native
+
+typecast_native_boolean_test_to_native:
+  sql: |
+    SELECT CAST(value IS TRUE AS text);
+  expected: |
+    SELECT (value IS TRUE)::text;
+  config:
+    format:
+      type_casting_style: native
+
+typecast_native_with_whitespace_to_literal:
+  sql: |
+    SELECT 1 ::  text;
+  expected: |
+    SELECT 1::text;
   config:
     format:
       type_casting_style: literal
@@ -231,7 +312,7 @@ typecast_literal_nested_casts_to_literal:
   sql: |
     SELECT text '1'::text;
   expected: |
-    SELECT CAST(text '1' AS text);
+    SELECT text '1'::text;
   config:
     format:
       type_casting_style: literal
@@ -241,6 +322,15 @@ typecast_standard_array_to_literal:
     SELECT CAST(ARRAY[1, 2] AS text[]);
   expected: |
     SELECT CAST(ARRAY[1, 2] AS text[]);
+  config:
+    format:
+      type_casting_style: literal
+
+typecast_native_array_to_literal:
+  sql: |
+    SELECT ARRAY[1, 2]::text[];
+  expected: |
+    SELECT ARRAY[1, 2]::text[];
   config:
     format:
       type_casting_style: literal

--- a/tests/fixtures/formatters/dml/typecast.yml
+++ b/tests/fixtures/formatters/dml/typecast.yml
@@ -1,0 +1,256 @@
+---
+formatter: TYPECAST
+
+typecast_native_to_default:
+  sql: |
+    SELECT '1'::text;
+  expected: |
+    SELECT CAST('1' AS text);
+
+typecast_standard_to_default:
+  sql: |
+    SELECT CAST('1' AS text);
+  expected: |
+    SELECT CAST('1' AS text);
+
+typecast_literal_to_default:
+  sql: |
+    SELECT text '1';
+  expected: |
+    SELECT CAST('1' AS text);
+
+typecast_literal_char_to_default:
+  sql: |
+    SELECT char '1';
+  expected: |
+    SELECT char '1';
+
+typecast_native_expression_to_default:
+  sql: |
+    SELECT (1 + 1)::text;
+  expected: |
+    SELECT CAST(1 + 1 AS text);
+
+typecast_standard_expression_to_default:
+  sql: |
+    SELECT CAST(1 + 1 AS text);
+  expected: |
+    SELECT CAST(1 + 1 AS text);
+
+typecast_native_binary_expression_to_default:
+  sql: |
+    SELECT (TRUE AND FALSE)::text
+  expected: |
+    SELECT CAST(TRUE AND FALSE AS text);
+
+typecast_native_nested_casts_to_default:
+  sql: |
+    SELECT 1::text::text;
+  expected: |
+    SELECT CAST(CAST(1 AS text) AS text);
+
+typecast_standard_nested_casts_to_default:
+  sql: |
+    SELECT CAST(CAST(1 AS text) AS text);
+  expected: |
+    SELECT CAST(CAST(1 AS text) AS text);
+
+typecast_native_array_to_default:
+  sql: |
+    SELECT ARRAY[1, 2]::text[];
+  expected: |
+    SELECT CAST(ARRAY[1, 2] AS text[]);
+
+typecast_standard_array_to_default:
+  sql: |
+    SELECT CAST(ARRAY[1, 2] AS integer[]);
+  expected: |
+    SELECT CAST(ARRAY[1, 2] AS integer[]);
+
+typecast_literal_array_to_default:
+  sql: |
+    SELECT ARRAY[text '1', text '2'];
+  expected: |
+    SELECT ARRAY[CAST('1' AS text)
+               , CAST('2' AS text)];
+
+typecast_native_to_standard:
+  sql: |
+    SELECT '1'::text;
+  expected: |
+    SELECT CAST('1' AS text);
+  config:
+    format:
+      type_casting_style: standard
+
+typecast_standard_to_standard:
+  sql: |
+    SELECT CAST('1' AS text);
+  expected: |
+    SELECT CAST('1' AS text);
+  config:
+    format:
+      type_casting_style: standard
+
+typecast_literal_to_standard:
+  sql: |
+    SELECT text '1';
+  expected: |
+    SELECT CAST('1' AS text);
+  config:
+    format:
+      type_casting_style: standard
+
+typecast_native_to_native:
+  sql: |
+    SELECT '1'::text;
+  expected: |
+    SELECT '1'::text;
+  config:
+    format:
+      type_casting_style: native
+
+typecast_standard_to_native:
+  sql: |
+    SELECT CAST('1' AS text);
+  expected: |
+    SELECT '1'::text;
+  config:
+    format:
+      type_casting_style: native
+
+typecast_literal_to_native:
+  sql: |
+    SELECT text '1';
+  expected: |
+    SELECT '1'::text;
+  config:
+    format:
+      type_casting_style: native
+
+typecast_literal_char_to_native:
+  sql: |
+    SELECT char 'xyz';
+  expected: |
+    SELECT char 'xyz';
+  config:
+    format:
+      type_casting_style: native
+
+typecast_standard_expression_to_native:
+  sql: |
+    SELECT CAST(1 + 1 AS text);
+  expected: |
+    SELECT (1 + 1)::text;
+  config:
+    format:
+      type_casting_style: native
+
+typecast_standard_binary_expression_to_native:
+  sql: |
+    SELECT CAST(TRUE AND FALSE AS text);
+  expected: |
+    SELECT (TRUE AND FALSE)::text;
+  config:
+    format:
+      type_casting_style: native
+
+typecast_standard_nested_casts_to_native:
+  sql: |
+    SELECT CAST(CAST(1 AS text) AS text);
+  expected: |
+    SELECT 1::text::text;
+  config:
+    format:
+      type_casting_style: native
+
+typecast_standard_array_to_native:
+  sql: |
+    SELECT CAST(ARRAY[1, 2] AS text[]);
+  expected: |
+    SELECT ARRAY[1, 2]::text[];
+  config:
+    format:
+      type_casting_style: native
+
+typecast_native_to_literal:
+  sql: |
+    SELECT '1'::text;
+  expected: |
+    SELECT text '1';
+  config:
+    format:
+      type_casting_style: literal
+
+typecast_literal_to_literal:
+  sql: |
+    SELECT text '1';
+  expected: |
+    SELECT text '1';
+  config:
+    format:
+      type_casting_style: literal
+
+typecast_standard_to_literal:
+  sql: |
+    SELECT CAST('1' AS text);
+  expected: |
+    SELECT text '1';
+  config:
+    format:
+      type_casting_style: literal
+
+typecast_literal_char_to_literal:
+  sql: |
+    SELECT char 'xyz';
+  expected: |
+    SELECT char 'xyz';
+  config:
+    format:
+      type_casting_style: literal
+
+typecast_standard_expression_to_literal:
+  sql: |
+    SELECT CAST(1 + 1 AS text);
+  expected: |
+    SELECT CAST(1 + 1 AS text);
+  config:
+    format:
+      type_casting_style: literal
+
+typecast_standard_binary_expression_to_literal:
+  sql: |
+    SELECT CAST(TRUE AND FALSE AS text);
+  expected: |
+    SELECT CAST(TRUE AND FALSE AS text);
+  config:
+    format:
+      type_casting_style: literal
+
+typecast_literal_nested_casts_to_literal:
+  sql: |
+    SELECT text '1'::text;
+  expected: |
+    SELECT CAST(text '1' AS text);
+  config:
+    format:
+      type_casting_style: literal
+
+typecast_standard_array_to_literal:
+  sql: |
+    SELECT CAST(ARRAY[1, 2] AS text[]);
+  expected: |
+    SELECT CAST(ARRAY[1, 2] AS text[]);
+  config:
+    format:
+      type_casting_style: literal
+
+typecast_literal_array_to_literal:
+  sql: |
+    SELECT ARRAY[text '1', text '2'];
+  expected: |
+    SELECT ARRAY[text '1'
+               , text '2'];
+  config:
+    format:
+      type_casting_style: literal

--- a/tests/fixtures/formatters/dml/typecast.yml
+++ b/tests/fixtures/formatters/dml/typecast.yml
@@ -173,6 +173,24 @@ typecast_standard_array_to_native:
     format:
       type_casting_style: native
 
+typecast_standard_function_to_native:
+  sql: |
+    SELECT CAST(lower(value) AS text);
+  expected: |
+    SELECT lower(value)::text;
+  config:
+    format:
+      type_casting_style: native
+
+typecast_standard_special_function_to_native:
+  sql: |
+    SELECT CAST(value AT TIME ZONE 'UTC' AS text);
+  expected: |
+    SELECT (value AT TIME ZONE 'UTC')::text;
+  config:
+    format:
+      type_casting_style: native
+
 typecast_native_to_literal:
   sql: |
     SELECT '1'::text;
@@ -268,6 +286,15 @@ typecast_native_expression_to_literal:
     SELECT (1 + 1)::text;
   expected: |
     SELECT (1 + 1)::text;
+  config:
+    format:
+      type_casting_style: literal
+
+typecast_native_special_function_to_literal:
+  sql: |
+    SELECT (value AT TIME ZONE 'UTC')::text;
+  expected: |
+    SELECT (value AT TIME ZONE 'UTC')::text;
   config:
     format:
       type_casting_style: literal

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -265,6 +265,35 @@ def test_cli_lint_missing_config_error(tmp_path: pathlib.Path) -> None:
         assert result.exit_code == 1
 
 
+@pytest.mark.parametrize("command", ["lint", "format"])
+def test_cli_invalid_config_value_error(
+    command: str,
+    tmp_path: pathlib.Path,
+) -> None:
+    """Test CLI invalid config value errors."""
+    config_content = """
+    [format]
+    type-casting-style = "invalid"
+    """
+    directory = tmp_path / "sub"
+    directory.mkdir()
+    (directory / config.CONFIG_FILE).write_text(config_content)
+
+    source_file = directory / TEST_FILE
+    source_file.write_text("SELECT 1;")
+
+    runner = testing.CliRunner()
+    with patch("os.getcwd", return_value=str(directory)):
+        result = runner.invoke(cli, [command, str(source_file)])
+
+    assert result.output == (
+        'Invalid config value for key "format.type-casting-style": "invalid". '
+        'Expected one of: "native", "standard", "literal"'
+        f"{noqa.NEW_LINE}"
+    )
+    assert result.exit_code == 1
+
+
 def test_cli_lint_config_file_from_environment_variable_not_found_error(
     tmp_path: pathlib.Path,
 ) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -266,7 +266,7 @@ def test_cli_lint_missing_config_error(tmp_path: pathlib.Path) -> None:
 
 
 @pytest.mark.parametrize("command", ["lint", "format"])
-def test_cli_invalid_config_value_error(
+def test_cli_invalid_type_casting_style_error(
     command: str,
     tmp_path: pathlib.Path,
 ) -> None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -106,6 +106,79 @@ def test_missing_config_error(tmp_path: pathlib.Path) -> None:
         assert excinfo.value.args[0] == "Missing config key: data-type"
 
 
+def test_invalid_type_casting_style_error(tmp_path: pathlib.Path) -> None:
+    """Test invalid type casting style error."""
+    config_content = """
+    [format]
+    type-casting-style = "invalid"
+    """
+    directory = tmp_path / "sub"
+    directory.mkdir()
+
+    config_file = directory / config.CONFIG_FILE
+    config_file.write_text(config_content)
+
+    with patch("os.getcwd", return_value=str(directory)):
+        assert pathlib.Path.cwd() == directory
+
+        with pytest.raises(errors.InvalidConfigValueError) as excinfo:
+            config.parse_config()
+
+        assert (
+            excinfo.value.args[0]
+            == 'Invalid config value for key "format.type-casting-style": '
+            '"invalid". Expected one of: "native", "standard", "literal"'
+        )
+
+
+def test_invalid_type_casting_style_error_suggests_close_match(
+    tmp_path: pathlib.Path,
+) -> None:
+    """Test invalid type casting style error suggests a close match."""
+    config_content = """
+    [format]
+    type-casting-style = "stand"
+    """
+    directory = tmp_path / "sub"
+    directory.mkdir()
+    (directory / config.CONFIG_FILE).write_text(config_content)
+
+    with (
+        patch("os.getcwd", return_value=str(directory)),
+        pytest.raises(errors.InvalidConfigValueError) as excinfo,
+    ):
+        config.parse_config()
+
+    assert (
+        excinfo.value.args[0]
+        == 'Invalid config value for key "format.type-casting-style": "stand". '
+        'Did you mean "standard"? Expected one of: "native", "standard", "literal"'
+    )
+
+
+def test_invalid_non_string_type_casting_style_error(tmp_path: pathlib.Path) -> None:
+    """Test invalid non-string type casting style error."""
+    config_content = """
+    [format]
+    type-casting-style = 1
+    """
+    directory = tmp_path / "sub"
+    directory.mkdir()
+    (directory / config.CONFIG_FILE).write_text(config_content)
+
+    with (
+        patch("os.getcwd", return_value=str(directory)),
+        pytest.raises(errors.InvalidConfigValueError) as excinfo,
+    ):
+        config.parse_config()
+
+    assert (
+        excinfo.value.args[0]
+        == 'Invalid config value for key "format.type-casting-style": "1". '
+        'Expected one of: "native", "standard", "literal"'
+    )
+
+
 def test_config_file_from_environment_variable_not_found_error() -> None:
     """Test config from environment variable not found error."""
     with patch.dict(

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -4,11 +4,11 @@ import typing
 import pathlib
 
 import pytest
-from pglast import parser
+from pglast import parser, stream as pglast_stream
 
 from tests import TEST_FILE, conftest
 from pgrubic import core
-from pgrubic.core import noqa
+from pgrubic.core import noqa, formatter as formatter_module
 
 
 @pytest.mark.parametrize(
@@ -46,6 +46,33 @@ def test_formatters(
         except parser.ParseError as error:
             msg = f"Formatted code is not a valid syntax: {error!s}"
             raise ValueError(msg) from error
+
+
+def test_configured_streams(formatter: core.Formatter) -> None:
+    """Test configured streams extend their corresponding pglast streams."""
+    raw_stream = formatter_module.RawStream(config=formatter.config)
+    indented_stream = formatter_module.IndentedStream(config=formatter.config)
+
+    assert isinstance(raw_stream, pglast_stream.RawStream)
+    assert raw_stream.config is formatter.config
+    assert isinstance(indented_stream, pglast_stream.IndentedStream)
+    assert indented_stream.config is formatter.config
+
+
+def test_concatenate_nodes_with_type_cast(formatter: core.Formatter) -> None:
+    """Test raw node concatenation uses the configured type-casting style."""
+    with conftest.update_config(
+        config=formatter.config,
+        overrides={"format": {"type_casting_style": core.enums.TypeCastingStyle.NATIVE}},
+    ):
+        result = formatter.format(
+            source_file=TEST_FILE,
+            source_code="CREATE INDEX idx ON tbl ((CAST(value AS text)));",
+        )
+
+    assert result.formatted_source_code == (
+        "CREATE INDEX idx\n    ON tbl ((value::text));\n"
+    )
 
 
 def test_format_parse_error(formatter: core.Formatter) -> None:

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -71,7 +71,9 @@ def test_concatenate_nodes_with_type_cast(formatter: core.Formatter) -> None:
         )
 
     assert result.formatted_source_code == (
-        "CREATE INDEX idx\n    ON tbl ((value::text));\n"
+        """CREATE INDEX idx
+    ON tbl ((value::text));
+"""
     )
 
 


### PR DESCRIPTION
## Background and Motivation
<!-- Why is this change needed? What problem does it solve? -->
This PR introduces a new formatter configuration option to control the SQL type-cast output style, along with validation, CLI error handling, defaults, and documentation updates.
## Summary of Changes
<!-- High-level overview of what was changed. -->
- Adds `format.type-casting-style` config (default `standard`) with validation + close-match suggestions.
- Introduces `InvalidConfigValueError` and handles it in CLI commands.
- Updates default config and docs, and adds tests for invalid config values (config + CLI).
## Type of change
<!-- Select the type of change. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Housekeeping (change that does not affect functionality)

## SQL Examples (if applicable)
<!-- Provide sample SQL to show before/after behavior of the linter/formatter. -->

```sql
-- Before
...

-- After
...
```

## Checklist
<!-- Checklist before requesting a review -->
- [x] I have read and followed the [contributing guidelines](https://github.com/bolajiwahab/pgrubic/blob/main/docs/docs/contributing.md)
- [x] I have checked that there are no other open [Pull Requests](https://github.com/bolajiwahab/pgrubic/pulls) for the same update/change
- [x] I have performed a self-review of my code
- [x] I have added/updated tests (positive + negative cases)
- [x] I have updated documentation (if applicable)

## Closes / Fixes
<!-- Link issues using keywords: Closes #123, Fixes #456 -->

## Additional information
<!-- Provide any additional information that might be helpful to the reviewer in reviewing this pull request -->
