### PR TITLE
feat: expose configuring output of special functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,10 @@ new-line-before-semicolon = false
 # Remove pg_catalog from functions by default
 remove-pg-catalog-from-functions = true
 
+# Rewrite supported function calls using equivalent SQL syntax by default,
+# e.g. pg_catalog.timezone('UTC', value) as value AT TIME ZONE 'UTC'
+rewrite-function-calls-as-equivalent-syntax = true
+
 # Separate statements by a certain number by of new line, 1 by default
 lines-between-statements = 1
 

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -118,6 +118,9 @@ new-line-before-semicolon = false
 # Remove pg_catalog from functions by default
 remove-pg-catalog-from-functions = true
 
+# Rewrite some function calls using their equivalent SQL syntax by default
+rewrite-function-calls-as-equivalent-syntax = true
+
 # Separate statements by a certain number by of new line, 1 by default
 lines-between-statements = 1
 

--- a/docs/docs/settings.md
+++ b/docs/docs/settings.md
@@ -668,6 +668,25 @@ type-casting-style = "native"
 ```
 </details>
 
+### **rewrite-function-calls-as-equivalent-syntax**
+If `true`, rewrite some function calls using their equivalent SQL syntax. For example,
+`pg_catalog.timezone('UTC', value)` is formatted as
+`value AT TIME ZONE 'UTC'`.
+
+**Type**: `bool`
+
+**Default**: `true`
+
+**Example**:
+<details open>
+<summary><strong>pgrubic.toml</strong></summary>
+
+```toml
+[format]
+rewrite-function-calls-as-equivalent-syntax = false
+```
+</details>
+
 ### **new-line-before-semicolon**
 If `true`, add a new line before each semicolon.
 

--- a/src/pgrubic/core/config.py
+++ b/src/pgrubic/core/config.py
@@ -686,6 +686,25 @@ type-casting-style = "native"
 ```
 </details>
 
+### **rewrite-function-calls-as-equivalent-syntax**
+If `true`, rewrite some function calls using their equivalent SQL syntax. For example,
+`pg_catalog.timezone('UTC', value)` is formatted as
+`value AT TIME ZONE 'UTC'`.
+
+**Type**: `bool`
+
+**Default**: `true`
+
+**Example**:
+<details open>
+<summary><strong>pgrubic.toml</strong></summary>
+
+```toml
+[format]
+rewrite-function-calls-as-equivalent-syntax = false
+```
+</details>
+
 ### **new-line-before-semicolon**
 If `true`, add a new line before each semicolon.
 
@@ -844,6 +863,7 @@ no-cache = true
     compact_parenthesized_lists_margin: int
     uppercase_keywords: bool
     type_casting_style: enums.TypeCastingStyle
+    rewrite_function_calls_as_equivalent_syntax: bool
     new_line_before_semicolon: bool
     lines_between_statements: int
     remove_pg_catalog_from_functions: bool
@@ -1157,6 +1177,9 @@ def parse_config(overrides: dict[str, typing.Any] | None = None) -> Config:
                 type_casting_style=_parse_type_casting_style(
                     config_format["type-casting-style"],
                 ),
+                rewrite_function_calls_as_equivalent_syntax=config_format[
+                    "rewrite-function-calls-as-equivalent-syntax"
+                ],
                 new_line_before_semicolon=config_format["new-line-before-semicolon"],
                 lines_between_statements=config_format["lines-between-statements"],
                 remove_pg_catalog_from_functions=config_format[

--- a/src/pgrubic/core/formatter.py
+++ b/src/pgrubic/core/formatter.py
@@ -200,7 +200,7 @@ class Formatter:
                         semicolon_after_last_statement=False,
                         remove_pg_catalog_from_functions=config.format.remove_pg_catalog_from_functions,
                         comma_at_eoln=not (config.format.comma_at_beginning),
-                        special_functions=True,
+                        special_functions=config.format.rewrite_function_calls_as_equivalent_syntax,
                     )
                     formatted_statement = output.apply_keyword_case(
                         text=output(statement.text),
@@ -307,6 +307,6 @@ class Formatter:
             separate_statements=self.config.format.lines_between_statements,
             remove_pg_catalog_from_functions=self.config.format.remove_pg_catalog_from_functions,
             comma_at_eoln=not (self.config.format.comma_at_beginning),
-            special_functions=True,
+            special_functions=self.config.format.rewrite_function_calls_as_equivalent_syntax,
         )
         return output.apply_keyword_case(text=output(source_ast))

--- a/src/pgrubic/pgrubic.toml
+++ b/src/pgrubic/pgrubic.toml
@@ -36,6 +36,7 @@ comma-at-beginning = true
 compact-parenthesized-lists-margin = 90
 uppercase-keywords = true
 type-casting-style = "standard"
+rewrite-function-calls-as-equivalent-syntax = true
 new-line-before-semicolon = false
 remove-pg-catalog-from-functions = true
 remove-default-index-access-method = true

--- a/tests/fixtures/formatters/dml/select.yml
+++ b/tests/fixtures/formatters/dml/select.yml
@@ -1,6 +1,22 @@
 ---
 formatter: SELECT
 
+select_rewrite_function_call_as_equivalent_syntax:
+  sql: |
+    SELECT pg_catalog.timezone('UTC', value);
+  expected: |
+    SELECT value AT TIME ZONE 'UTC';
+
+select_do_not_rewrite_function_call_as_equivalent_syntax:
+  sql: |
+    SELECT pg_catalog.timezone('UTC', value);
+  expected: |
+    SELECT pg_catalog.timezone('UTC', value);
+  config:
+    format:
+      remove_pg_catalog_from_functions: false
+      rewrite_function_calls_as_equivalent_syntax: false
+
 simple_select:
   sql: |
     SELECT a, b, c FROM films WHERE date_prod >= '2002-01-01'

--- a/tests/fixtures/formatters/dml/typecast.yml
+++ b/tests/fixtures/formatters/dml/typecast.yml
@@ -101,6 +101,15 @@ typecast_literal_to_standard:
     format:
       type_casting_style: standard
 
+typecast_native_function_with_equivalent_syntax_to_standard:
+  sql: |
+    SELECT pg_catalog.timezone('UTC', value)::text;
+  expected: |
+    SELECT CAST(value AT TIME ZONE 'UTC' AS text);
+  config:
+    format:
+      type_casting_style: standard
+
 typecast_native_to_native:
   sql: |
     SELECT '1'::text;
@@ -182,9 +191,9 @@ typecast_standard_function_to_native:
     format:
       type_casting_style: native
 
-typecast_standard_special_function_to_native:
+typecast_standard_function_with_equivalent_syntax_to_native:
   sql: |
-    SELECT CAST(value AT TIME ZONE 'UTC' AS text);
+    SELECT CAST(pg_catalog.timezone('UTC', value) AS text);
   expected: |
     SELECT (value AT TIME ZONE 'UTC')::text;
   config:
@@ -290,16 +299,65 @@ typecast_native_expression_to_literal:
     format:
       type_casting_style: literal
 
-typecast_native_special_function_to_literal:
+typecast_standard_function_to_literal:
   sql: |
-    SELECT (value AT TIME ZONE 'UTC')::text;
+    SELECT CAST(lower(value) AS text);
+  expected: |
+    SELECT CAST(lower(value) AS text);
+  config:
+    format:
+      type_casting_style: literal
+
+typecast_native_function_to_literal:
+  sql: |
+    SELECT lower(value)::text;
+  expected: |
+    SELECT lower(value)::text;
+  config:
+    format:
+      type_casting_style: literal
+
+typecast_standard_function_with_equivalent_syntax_to_literal:
+  sql: |
+    SELECT CAST(pg_catalog.timezone('UTC', value) AS text);
+  expected: |
+    SELECT CAST(value AT TIME ZONE 'UTC' AS text);
+  config:
+    format:
+      type_casting_style: literal
+
+typecast_native_function_with_equivalent_syntax_to_literal:
+  sql: |
+    SELECT pg_catalog.timezone('UTC', value)::text;
   expected: |
     SELECT (value AT TIME ZONE 'UTC')::text;
   config:
     format:
       type_casting_style: literal
 
-typecast_native_null_test_to_native:
+typecast_standard_function_to_literal_without_equivalent_syntax_rewrite:
+  sql: |
+    SELECT CAST(pg_catalog.timezone('UTC', value) AS text);
+  expected: |
+    SELECT CAST(pg_catalog.timezone('UTC', value) AS text);
+  config:
+    format:
+      type_casting_style: literal
+      rewrite_function_calls_as_equivalent_syntax: false
+      remove_pg_catalog_from_functions: false
+
+typecast_native_function_to_literal_without_equivalent_syntax_rewrite:
+  sql: |
+    SELECT pg_catalog.timezone('UTC', value)::text;
+  expected: |
+    SELECT pg_catalog.timezone('UTC', value)::text;
+  config:
+    format:
+      type_casting_style: literal
+      rewrite_function_calls_as_equivalent_syntax: false
+      remove_pg_catalog_from_functions: false
+
+typecast_standard_null_test_to_native:
   sql: |
     SELECT CAST(value IS NULL AS text);
   expected: |
@@ -308,7 +366,7 @@ typecast_native_null_test_to_native:
     format:
       type_casting_style: native
 
-typecast_native_boolean_test_to_native:
+typecast_standard_boolean_test_to_native:
   sql: |
     SELECT CAST(value IS TRUE AS text);
   expected: |

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -37,6 +37,7 @@ def test_config_from_current_working_directory(tmp_path: pathlib.Path) -> None:
     diff = true
     compact-parenthesized-lists-margin = 100
     uppercase-keywords = false
+    rewrite-function-calls-as-equivalent-syntax = false
     """
     directory = tmp_path / "sub"
     directory.mkdir()
@@ -50,6 +51,7 @@ def test_config_from_current_working_directory(tmp_path: pathlib.Path) -> None:
         parsed_config = config.parse_config()
         assert parsed_config.format.diff is True
         assert parsed_config.format.uppercase_keywords is False
+        assert parsed_config.format.rewrite_function_calls_as_equivalent_syntax is False
         assert (
             parsed_config.format.compact_parenthesized_lists_margin
             == expected_compact_parenthesized_lists_margin


### PR DESCRIPTION
## Background and Motivation
<!-- Why is this change needed? What problem does it solve? -->
This PR makes the formatter’s “special functions” rewriting behavior configurable via a new `format.rewrite-function-calls-as-equivalent-syntax` setting, so users can opt out of rewriting supported function calls into equivalent SQL syntax (e.g., `pg_catalog.timezone(...)` → `... AT TIME ZONE ...`).
## Summary of Changes
<!-- High-level overview of what was changed. -->
- Add `rewrite-function-calls-as-equivalent-syntax` to the default configuration and config parsing, and wire it into the formatter’s `special_functions` stream option.
- Extend formatter fixture coverage to validate rewrite vs. no-rewrite behavior (including within type casts).
- Document the new setting in README and docs.
## Type of change
<!-- Select the type of change. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Housekeeping (change that does not affect functionality)

## SQL Examples (if applicable)
<!-- Provide sample SQL to show before/after behavior of the linter/formatter. -->

```sql
-- Before
...

-- After
...
```

## Checklist
<!-- Checklist before requesting a review -->
- [ ] I have read and followed the [contributing guidelines](https://github.com/bolajiwahab/pgrubic/blob/main/docs/docs/contributing.md)
- [ ] I have checked that there are no other open [Pull Requests](https://github.com/bolajiwahab/pgrubic/pulls) for the same update/change
- [ ] I have performed a self-review of my code
- [ ] I have added/updated tests (positive + negative cases)
- [ ] I have updated documentation (if applicable)

## Closes / Fixes
<!-- Link issues using keywords: Closes #123, Fixes #456 -->

## Additional information
<!-- Provide any additional information that might be helpful to the reviewer in reviewing this pull request -->
