### PR TITLE
refactor!: standardize configured streams across formatters

### DIFF
--- a/src/pgrubic/core/formatter.py
+++ b/src/pgrubic/core/formatter.py
@@ -31,6 +31,22 @@ class RawStream(stream.RawStream):
         self.config = config
         self.source_code = source_code
 
+    def write_empty_space(self) -> None:
+        """Write an empty space."""
+        self.write("")
+
+    def print_parenthesized_list(
+        self,
+        nodes: tuple[ast.Node, ...],
+        *,
+        closing_indent: int,
+        continuation_indent: int = 4,
+    ) -> None:
+        """Print a compact parenthesized list."""
+        self.space(force=True)
+        with self.expression(need_parens=True):
+            self.print_list(nodes, standalone_items=False)
+
 
 class IndentedStream(stream.IndentedStream):
     """Indented SQL parse tree writer."""
@@ -131,6 +147,9 @@ class IndentedStream(stream.IndentedStream):
             self.dedent()
 
 
+type PrinterOutput = RawStream | IndentedStream
+
+
 class Formatter:
     """Format source code."""
 
@@ -143,6 +162,18 @@ class Formatter:
         """Initialize variables."""
         self.formatters = formatters()
         self.config = config
+
+    def create_raw_stream(self) -> RawStream:
+        """Create a raw stream with the formatter's configuration."""
+        return RawStream(
+            config=self.config,
+            special_functions=(
+                self.config.format.rewrite_function_calls_as_equivalent_syntax
+            ),
+            remove_pg_catalog_from_functions=(
+                self.config.format.remove_pg_catalog_from_functions
+            ),
+        )
 
     @staticmethod
     def run(

--- a/src/pgrubic/core/formatter.py
+++ b/src/pgrubic/core/formatter.py
@@ -31,8 +31,8 @@ class RawStream(stream.RawStream):
         self.config = config
         self.source_code = source_code
 
-    def write_empty_space(self) -> None:
-        """Write an empty space."""
+    def write_empty_string(self) -> None:
+        """Write an empty string (no-op)."""
         self.write("")
 
     def print_parenthesized_list(
@@ -43,6 +43,8 @@ class RawStream(stream.RawStream):
         continuation_indent: int = 4,
     ) -> None:
         """Print a compact parenthesized list."""
+        # RawStream suppresses pending separators before "(", so force the
+        # caller-requested space to match pglast's DDL serialization.
         self.space(force=True)
         with self.expression(need_parens=True):
             self.print_list(nodes, standalone_items=False)
@@ -111,8 +113,8 @@ class IndentedStream(stream.IndentedStream):
 
         return output.getvalue()
 
-    def write_empty_space(self) -> None:
-        """Write an empty space."""
+    def write_empty_string(self) -> None:
+        """Write an empty string (no-op)."""
         self.write("")
 
     def print_parenthesized_list(

--- a/src/pgrubic/core/linter.py
+++ b/src/pgrubic/core/linter.py
@@ -568,7 +568,8 @@ class Linter:
 
                 inline_sql_statements = (
                     pgrubic_visitors.extract_nested_inline_sql_statements(
-                        parse_tree,
+                        node=parse_tree,
+                        raw_stream_factory=self.formatter.create_raw_stream,
                     )
                 )
 

--- a/src/pgrubic/core/visitors.py
+++ b/src/pgrubic/core/visitors.py
@@ -3,15 +3,24 @@
 import typing
 from collections import deque
 
-from pglast import ast, parser, stream, visitors, parse_plpgsql
+from pglast import ast, parser, visitors, parse_plpgsql
+
+from pgrubic.core import formatter
+
+RawStreamFactory = typing.Callable[[], formatter.RawStream]
 
 
 class InlineSQLVisitor(visitors.Visitor):
     """Visitor for extracting inline SQL statements from PLpgSQL and function calls."""
 
-    def __init__(self) -> None:
+    def __init__(self, raw_stream_factory: RawStreamFactory) -> None:
         """Instantiate variables."""
+        self.raw_stream_factory = raw_stream_factory
         self._sql_statements: list[str] = []
+
+    def _render_raw(self, source: str | ast.Node) -> str:
+        """Render SQL with a fresh configured raw stream."""
+        return typing.cast(str, self.raw_stream_factory()(source))
 
     def visit_CreateFunctionStmt(
         self,
@@ -23,14 +32,14 @@ class InlineSQLVisitor(visitors.Visitor):
             return
 
         _sql_statements = self._extract_sql_statements_from_plpgsql(
-            parse_plpgsql(stream.RawStream()(node)),
+            parse_plpgsql(self._render_raw(node)),
         )
         self._sql_statements.extend(_sql_statements)
 
     def visit_DoStmt(self, ancestors: visitors.Ancestor, node: ast.DoStmt) -> None:
         """Visit DoStmt."""
         _sql_statements = self._extract_sql_statements_from_plpgsql(
-            parse_plpgsql(stream.RawStream()(node)),
+            parse_plpgsql(self._render_raw(node)),
         )
         self._sql_statements.extend(_sql_statements)
 
@@ -42,10 +51,14 @@ class InlineSQLVisitor(visitors.Visitor):
         """Visit FuncCall."""
         if node.args:
             for arg in node.args:
-                if isinstance(arg, ast.A_Const) and isinstance(arg.val, ast.String):
+                if (
+                    isinstance(arg, ast.A_Const)
+                    and isinstance(arg.val, ast.String)
+                    and isinstance(arg.val.sval, str)
+                ):
                     try:
                         # might not be an SQL statement.
-                        statement = stream.RawStream()(arg.val.sval)
+                        statement = self._render_raw(arg.val.sval)
                         # if statement is PLpgSQL, it would be processed at a later pass
                         self._sql_statements.append(statement)
                     except parser.ParseError:
@@ -91,15 +104,23 @@ class InlineSQLVisitor(visitors.Visitor):
         return self._sql_statements
 
 
-def visit_inline_sql(node: tuple[ast.RawStmt, ...]) -> list[str]:
+def visit_inline_sql(
+    *,
+    node: tuple[ast.RawStmt, ...],
+    raw_stream_factory: RawStreamFactory,
+) -> list[str]:
     """Visit inline SQL."""
-    inline_sql_visitor = InlineSQLVisitor()
+    inline_sql_visitor = InlineSQLVisitor(raw_stream_factory=raw_stream_factory)
     inline_sql_visitor(node)
 
     return inline_sql_visitor.get_sql_statements()
 
 
-def extract_nested_inline_sql_statements(node: tuple[ast.RawStmt, ...]) -> list[str]:
+def extract_nested_inline_sql_statements(
+    *,
+    node: tuple[ast.RawStmt, ...],
+    raw_stream_factory: RawStreamFactory,
+) -> list[str]:
     """Extract nested inline SQL statements from PLpgSQL and function calls
     using iterative breadth-first walk.
     """
@@ -110,7 +131,10 @@ def extract_nested_inline_sql_statements(node: tuple[ast.RawStmt, ...]) -> list[
     while queue:
         current_tree = queue.popleft()
 
-        for statement in visit_inline_sql(current_tree):
+        for statement in visit_inline_sql(
+            node=current_tree,
+            raw_stream_factory=raw_stream_factory,
+        ):
             statements.append(statement)
             child_tree = parser.parse_sql(statement)
             queue.append(child_tree)

--- a/src/pgrubic/formatters/ddl/column.py
+++ b/src/pgrubic/formatters/ddl/column.py
@@ -1,10 +1,12 @@
 """Formatter for column."""
 
-from pglast import ast, enums, stream, printers
+from pglast import ast, enums, printers
+
+from pgrubic.core import formatter
 
 
 @printers.node_printer(ast.ColumnDef, override=True)
-def column_def(node: ast.ColumnDef, output: stream.RawStream) -> None:
+def column_def(node: ast.ColumnDef, output: formatter.PrinterOutput) -> None:
     """Printer for ColumnDef."""
     if node.colname:
         output.print_name(node.colname)

--- a/src/pgrubic/formatters/ddl/constraint.py
+++ b/src/pgrubic/formatters/ddl/constraint.py
@@ -1,12 +1,13 @@
 """Formatter for constraint."""
 
-from pglast import ast, enums, stream, printers
+from pglast import ast, enums, printers
 
 from pgrubic import Operators
+from pgrubic.core import formatter
 
 
 @printers.node_printer(ast.Constraint, override=True)
-def constraint(node: ast.Constraint, output: stream.RawStream) -> None:
+def constraint(node: ast.Constraint, output: formatter.PrinterOutput) -> None:
     """Printer for Constraint."""
     if node.conname:
         output.swrite("CONSTRAINT")
@@ -60,7 +61,7 @@ def constraint(node: ast.Constraint, output: stream.RawStream) -> None:
 
 
 @printers.node_printer(ast.Constraint, ast.DefElem, override=True)
-def constraint_def_elem(node: ast.DefElem, output: stream.RawStream) -> None:
+def constraint_def_elem(node: ast.DefElem, output: formatter.PrinterOutput) -> None:
     """Printer for Constraint defelem."""
     output.print_name(node.defname)
     if node.arg:

--- a/src/pgrubic/formatters/ddl/database.py
+++ b/src/pgrubic/formatters/ddl/database.py
@@ -1,12 +1,16 @@
 """Formatter for database."""
 
-from pglast import ast, stream, printers
+from pglast import ast, printers
 
 from pgrubic import Operators
+from pgrubic.core import formatter
 
 
 @printers.node_printer(ast.CreatedbStmt, ast.DefElem, override=True)
-def create_db_stmt_def_elem(node: ast.DefElem, output: stream.RawStream) -> None:
+def create_db_stmt_def_elem(
+    node: ast.DefElem,
+    output: formatter.PrinterOutput,
+) -> None:
     """Printer for CreatedbStmt defelem."""
     option = node.defname
     if option == "connection_limit":
@@ -30,7 +34,7 @@ def create_db_stmt_def_elem(node: ast.DefElem, output: stream.RawStream) -> None
 
 
 @printers.node_printer(ast.DropdbStmt, override=True)
-def drop_db_stmt(node: ast.DropdbStmt, output: stream.RawStream) -> None:
+def drop_db_stmt(node: ast.DropdbStmt, output: formatter.PrinterOutput) -> None:
     """Printer for DropdbStmt."""
     output.write("DROP DATABASE")
     if node.missing_ok:
@@ -50,6 +54,6 @@ def drop_db_stmt(node: ast.DropdbStmt, output: stream.RawStream) -> None:
 
 
 @printers.node_printer(ast.DropdbStmt, ast.DefElem, override=True)
-def drop_db_stmt_def_elem(node: ast.DefElem, output: stream.RawStream) -> None:
+def drop_db_stmt_def_elem(node: ast.DefElem, output: formatter.PrinterOutput) -> None:
     """Printer for DropdbStmt defelem."""
     output.write(node.defname.upper())

--- a/src/pgrubic/formatters/ddl/enum.py
+++ b/src/pgrubic/formatters/ddl/enum.py
@@ -1,12 +1,16 @@
 """Formatter for enum."""
 
-from pglast import ast, stream, printers
+from pglast import ast, printers
 
+from pgrubic.core import formatter
 from pgrubic.formatters.ddl import IF_NOT_EXISTS
 
 
 @printers.node_printer(ast.CreateEnumStmt, override=True)
-def create_enum_stmt(node: ast.CreateEnumStmt, output: stream.RawStream) -> None:
+def create_enum_stmt(
+    node: ast.CreateEnumStmt,
+    output: formatter.PrinterOutput,
+) -> None:
     """Printer for CreateEnumStmt."""
     output.write("CREATE TYPE")
     output.space()
@@ -21,7 +25,7 @@ def create_enum_stmt(node: ast.CreateEnumStmt, output: stream.RawStream) -> None
 
 
 @printers.node_printer(ast.AlterEnumStmt, override=True)
-def alter_enum_stmt(node: ast.AlterEnumStmt, output: stream.RawStream) -> None:
+def alter_enum_stmt(node: ast.AlterEnumStmt, output: formatter.PrinterOutput) -> None:
     """Printer for AlterEnumStmt."""
     output.write("ALTER TYPE")
     output.space()

--- a/src/pgrubic/formatters/ddl/function.py
+++ b/src/pgrubic/formatters/ddl/function.py
@@ -1,9 +1,9 @@
 # mypy: disable-error-code="union-attr"
 """Formatter for function/procedure."""
 
-from pglast import ast, enums, stream, printers
+from pglast import ast, enums, printers
 
-from pgrubic.core import Formatter, noqa, config
+from pgrubic.core import Formatter, noqa, config, formatter
 
 _config: config.Config = config.parse_config()
 
@@ -11,7 +11,7 @@ _config: config.Config = config.parse_config()
 @printers.node_printer(ast.CreateFunctionStmt, override=True)
 def create_function_stmt(
     node: ast.CreateFunctionStmt,
-    output: stream.RawStream,
+    output: formatter.PrinterOutput,
 ) -> None:
     """Printer for CreateFunctionStmt."""
     output.write("CREATE")
@@ -127,7 +127,7 @@ def create_function_stmt(
 )
 def create_function_option(  # noqa: PLR0911
     node: ast.CreateFunctionStmt | ast.AlterFunctionStmt | ast.DoStmt | ast.DefElem,
-    output: stream.RawStream,
+    output: formatter.PrinterOutput,
 ) -> None:
     """Printer for function options."""
     option = node.defname
@@ -255,7 +255,10 @@ def create_function_option(  # noqa: PLR0911
 
 
 @printers.node_printer(ast.AlterFunctionStmt, override=True)
-def alter_function_stmt(node: ast.AlterFunctionStmt, output: stream.RawStream) -> None:
+def alter_function_stmt(
+    node: ast.AlterFunctionStmt,
+    output: formatter.PrinterOutput,
+) -> None:
     """Printer for AlterFunctionStmt."""
     output.write("ALTER")
     output.space()

--- a/src/pgrubic/formatters/ddl/index.py
+++ b/src/pgrubic/formatters/ddl/index.py
@@ -12,7 +12,7 @@ DEFAULT_GUTTER: typing.Final[int] = 6
 
 
 @printers.node_printer(ast.IndexStmt, override=True)
-def index_stmt(node: ast.IndexStmt, output: formatter.IndentedStream) -> None:
+def index_stmt(node: ast.IndexStmt, output: formatter.PrinterOutput) -> None:
     """Printer for IndexStmt."""
     output.write("CREATE")
     output.space()

--- a/src/pgrubic/formatters/ddl/owner.py
+++ b/src/pgrubic/formatters/ddl/owner.py
@@ -1,10 +1,15 @@
 """Printer for AlterOwnerStmt."""
 
-from pglast import ast, enums, stream, printers
+from pglast import ast, enums, printers
+
+from pgrubic.core import formatter
 
 
 @printers.node_printer(ast.AlterOwnerStmt, override=True)
-def alter_owner_stmt(node: ast.AlterOwnerStmt, output: stream.RawStream) -> None:
+def alter_owner_stmt(
+    node: ast.AlterOwnerStmt,
+    output: formatter.PrinterOutput,
+) -> None:
     """Printer for AlterOwnerStmt."""
     output.write("ALTER")
     output.space()

--- a/src/pgrubic/formatters/ddl/rename.py
+++ b/src/pgrubic/formatters/ddl/rename.py
@@ -1,11 +1,13 @@
 """Formatter for rename."""
 
-from pglast import ast, enums, stream, printers
+from pglast import ast, enums, printers
 from pglast.printers.ddl import OBJECT_NAMES
+
+from pgrubic.core import formatter
 
 
 @printers.node_printer(ast.RenameStmt, override=True)
-def rename_stmt(node: ast.RenameStmt, output: stream.RawStream) -> None:
+def rename_stmt(node: ast.RenameStmt, output: formatter.PrinterOutput) -> None:
     """Printer for RenameStmt."""
     objtype = node.renameType
     output.write("ALTER")

--- a/src/pgrubic/formatters/ddl/schema.py
+++ b/src/pgrubic/formatters/ddl/schema.py
@@ -1,12 +1,16 @@
 """Printers for SchemaStmt."""
 
-from pglast import ast, enums, stream, printers
+from pglast import ast, enums, printers
 
+from pgrubic.core import formatter
 from pgrubic.formatters.ddl import IF_EXISTS, IF_NOT_EXISTS
 
 
 @printers.node_printer(ast.CreateSchemaStmt, override=True)
-def create_schema_stmt(node: ast.CreateSchemaStmt, output: stream.RawStream) -> None:
+def create_schema_stmt(
+    node: ast.CreateSchemaStmt,
+    output: formatter.PrinterOutput,
+) -> None:
     """Print a CreateSchemaStmt node."""
     output.writes("CREATE SCHEMA")
 
@@ -32,7 +36,7 @@ def create_schema_stmt(node: ast.CreateSchemaStmt, output: stream.RawStream) -> 
 @printers.node_printer(ast.AlterObjectSchemaStmt, override=True)
 def alter_object_schema_stmt(
     node: ast.AlterObjectSchemaStmt,
-    output: stream.RawStream,
+    output: formatter.PrinterOutput,
 ) -> None:
     """Print an AlterObjectSchemaStmt node."""
     objtype = node.objectType

--- a/src/pgrubic/formatters/ddl/table.py
+++ b/src/pgrubic/formatters/ddl/table.py
@@ -176,7 +176,7 @@ def create_stmt(
             output.newline()
             output.space(clause_indent)
     elif node.partbound:
-        output.write_empty_space()
+        output.write_empty_string()
     elif not node.ofTypename:
         output.space()
         output.write("()")

--- a/src/pgrubic/formatters/ddl/table.py
+++ b/src/pgrubic/formatters/ddl/table.py
@@ -1,13 +1,13 @@
 """Formatter for table."""
 
-from pglast import ast, enums, stream, printers
+from pglast import ast, enums, printers
 
 from pgrubic.core import formatter
 from pgrubic.formatters.ddl import IF_EXISTS, IF_NOT_EXISTS
 
 
 @printers.node_printer(ast.IntoClause, override=True)
-def into_clause(node: ast.IntoClause, output: formatter.IndentedStream) -> None:
+def into_clause(node: ast.IntoClause, output: formatter.PrinterOutput) -> None:
     """Printer for IntoClause."""
     output.print_node(node.rel)
 
@@ -51,7 +51,7 @@ def into_clause(node: ast.IntoClause, output: formatter.IndentedStream) -> None:
 
 
 @printers.node_printer(ast.PartitionSpec, override=True)
-def partition_spec(node: ast.PartitionSpec, output: stream.RawStream) -> None:
+def partition_spec(node: ast.PartitionSpec, output: formatter.PrinterOutput) -> None:
     """Printer for PartitionSpec."""
     strategy = {
         enums.PartitionStrategy.PARTITION_STRATEGY_LIST: "LIST",
@@ -66,7 +66,10 @@ def partition_spec(node: ast.PartitionSpec, output: stream.RawStream) -> None:
 
 
 @printers.node_printer(ast.CreateTableAsStmt, override=True)
-def create_table_as_stmt(node: ast.CreateTableAsStmt, output: stream.RawStream) -> None:
+def create_table_as_stmt(
+    node: ast.CreateTableAsStmt,
+    output: formatter.PrinterOutput,
+) -> None:
     """Printer for CreateTableAsStmt."""
     output.writes("CREATE")
     output.space()
@@ -95,7 +98,7 @@ def create_table_as_stmt(node: ast.CreateTableAsStmt, output: stream.RawStream) 
 @printers.node_printer(ast.CreateForeignTableStmt, override=True)
 def create_foreign_table_stmt(
     node: ast.CreateForeignTableStmt,
-    output: stream.RawStream,
+    output: formatter.PrinterOutput,
 ) -> None:
     """Printer for CreateForeignTableStmt."""
     output.print_node(node.base)
@@ -125,7 +128,7 @@ def create_foreign_table_stmt(
 @printers.node_printer(ast.CreateStmt, override=True)
 def create_stmt(
     node: ast.CreateStmt,
-    output: formatter.IndentedStream,
+    output: formatter.PrinterOutput,
 ) -> None:
     """Printer for CreateStmt."""
     clause_indent = 4 if node.partbound else 0
@@ -164,7 +167,7 @@ def create_stmt(
         columns = [x for x in node.tableElts if not isinstance(x, ast.Constraint)] + [
             x for x in node.tableElts if isinstance(x, ast.Constraint)
         ]
-        output.space()
+        output.space(force=True)
 
         with output.expression(need_parens=True):
             output.newline()
@@ -233,7 +236,10 @@ def create_stmt(
 
 
 @printers.node_printer(ast.AlterTableStmt, override=True)
-def alter_table_stmt(node: ast.AlterTableStmt, output: stream.RawStream) -> None:
+def alter_table_stmt(
+    node: ast.AlterTableStmt,
+    output: formatter.PrinterOutput,
+) -> None:
     """Printer for AlterTableStmt."""
     output.write("ALTER")
     output.space()

--- a/src/pgrubic/formatters/ddl/view.py
+++ b/src/pgrubic/formatters/ddl/view.py
@@ -1,10 +1,12 @@
 """Formatter for view."""
 
-from pglast import ast, enums, stream, printers
+from pglast import ast, enums, printers
+
+from pgrubic.core import formatter
 
 
 @printers.node_printer(ast.ViewStmt, override=True)
-def view_stmt(node: ast.ViewStmt, output: stream.RawStream) -> None:
+def view_stmt(node: ast.ViewStmt, output: formatter.PrinterOutput) -> None:
     """Printer for ViewStmt."""
     output.write("CREATE")
     output.space()

--- a/src/pgrubic/formatters/dml/boolean.py
+++ b/src/pgrubic/formatters/dml/boolean.py
@@ -1,6 +1,8 @@
 """Formatter for boolean expressions."""
 
-from pglast import ast, enums, stream, printers
+from pglast import ast, enums, printers
+
+from pgrubic.core import formatter
 
 
 def bool_expr_needs_to_be_wrapped_in_parens(node: ast.BoolExpr) -> bool:
@@ -12,7 +14,7 @@ def bool_expr_needs_to_be_wrapped_in_parens(node: ast.BoolExpr) -> bool:
 
 
 @printers.node_printer(ast.BoolExpr, override=True)
-def bool_expr(node: ast.BoolExpr, output: stream.RawStream) -> None:
+def bool_expr(node: ast.BoolExpr, output: formatter.PrinterOutput) -> None:
     """Printer for BoolExpr."""
     in_target_list = isinstance(node.ancestors[0], ast.ResTarget)  # type: ignore[attr-defined]
     bool_expr_in_ancestors = ast.BoolExpr in node.ancestors  # type: ignore[attr-defined]

--- a/src/pgrubic/formatters/dml/cte.py
+++ b/src/pgrubic/formatters/dml/cte.py
@@ -1,10 +1,12 @@
 """Formatter for CTEs."""
 
-from pglast import ast, stream, printers
+from pglast import ast, printers
+
+from pgrubic.core import formatter
 
 
 @printers.node_printer(ast.WithClause, override=True)
-def with_clause(node: ast.WithClause, output: stream.RawStream) -> None:
+def with_clause(node: ast.WithClause, output: formatter.PrinterOutput) -> None:
     """Printer for WithClause."""
     relative_indent = -2
 
@@ -15,7 +17,10 @@ def with_clause(node: ast.WithClause, output: stream.RawStream) -> None:
 
 
 @printers.node_printer(ast.CommonTableExpr, override=True)
-def common_table_expr(node: ast.CommonTableExpr, output: stream.RawStream) -> None:
+def common_table_expr(
+    node: ast.CommonTableExpr,
+    output: formatter.PrinterOutput,
+) -> None:
     """Printer for CommonTableExpr."""
     output.print_name(node.ctename)
     if node.aliascolnames:

--- a/src/pgrubic/formatters/dml/delete.py
+++ b/src/pgrubic/formatters/dml/delete.py
@@ -1,10 +1,12 @@
 """Formatters for delete."""
 
-from pglast import ast, stream, printers
+from pglast import ast, printers
+
+from pgrubic.core import formatter
 
 
 @printers.node_printer(ast.DeleteStmt, override=True)
-def delete_stmt(node: ast.DeleteStmt, output: stream.RawStream) -> None:
+def delete_stmt(node: ast.DeleteStmt, output: formatter.PrinterOutput) -> None:
     """Printer for DeleteStmt."""
     with output.push_indent():
         if node.withClause:

--- a/src/pgrubic/formatters/dml/insert.py
+++ b/src/pgrubic/formatters/dml/insert.py
@@ -1,10 +1,12 @@
 """Formatter for insert."""
 
-from pglast import ast, enums, stream, printers
+from pglast import ast, enums, printers
+
+from pgrubic.core import formatter
 
 
 @printers.node_printer(ast.InferClause, override=True)
-def infer_clause(node: ast.InferClause, output: stream.RawStream) -> None:
+def infer_clause(node: ast.InferClause, output: formatter.PrinterOutput) -> None:
     """Printer for InferClause."""
     if node.conname:
         output.swrite("ON CONSTRAINT")
@@ -25,7 +27,10 @@ def infer_clause(node: ast.InferClause, output: stream.RawStream) -> None:
 
 
 @printers.node_printer(ast.OnConflictClause, override=True)
-def on_conflict_clause(node: ast.OnConflictClause, output: stream.RawStream) -> None:
+def on_conflict_clause(
+    node: ast.OnConflictClause,
+    output: formatter.PrinterOutput,
+) -> None:
     """Printer for OnConflictClause."""
     on_conflict_action = enums.OnConflictAction
     if node.infer:
@@ -50,7 +55,7 @@ def on_conflict_clause(node: ast.OnConflictClause, output: stream.RawStream) -> 
 
 
 @printers.node_printer(ast.InsertStmt, override=True)
-def insert_stmt(node: ast.InsertStmt, output: stream.RawStream) -> None:
+def insert_stmt(node: ast.InsertStmt, output: formatter.PrinterOutput) -> None:
     """Printer for InsertStmt."""
     with output.push_indent():
         if node.withClause:

--- a/src/pgrubic/formatters/dml/join.py
+++ b/src/pgrubic/formatters/dml/join.py
@@ -1,10 +1,12 @@
 """Formatter for JOIN statements."""
 
-from pglast import ast, enums, stream, printers
+from pglast import ast, enums, printers
+
+from pgrubic.core import formatter
 
 
 @printers.node_printer(ast.JoinExpr, override=True)
-def join_expr(node: ast.JoinExpr, output: stream.RawStream) -> None:
+def join_expr(node: ast.JoinExpr, output: formatter.PrinterOutput) -> None:
     """Printer for JoinExpr."""
     indent = (
         -6

--- a/src/pgrubic/formatters/dml/select.py
+++ b/src/pgrubic/formatters/dml/select.py
@@ -1,10 +1,12 @@
 """Formatter for SELECT statements."""
 
-from pglast import ast, enums, stream, printers
+from pglast import ast, enums, printers
+
+from pgrubic.core import formatter
 
 
 @printers.node_printer(ast.SubLink, override=True)
-def sub_link(node: ast.SubLink, output: stream.RawStream) -> None:
+def sub_link(node: ast.SubLink, output: formatter.PrinterOutput) -> None:
     """Printer for SubLink."""
     if node.subLinkType == enums.SubLinkType.EXISTS_SUBLINK:
         output.write("EXISTS")
@@ -83,7 +85,7 @@ def subexpression_needs_parentheses(node: ast.SelectStmt) -> bool:
 
 
 @printers.node_printer(ast.SelectStmt, override=True)
-def select_stmt(node: ast.SelectStmt, output: stream.RawStream) -> None:
+def select_stmt(node: ast.SelectStmt, output: formatter.PrinterOutput) -> None:
     """Printer for SelectStmt."""
     with output.push_indent():
         if node.withClause:
@@ -256,7 +258,7 @@ def select_stmt(node: ast.SelectStmt, output: stream.RawStream) -> None:
 
 
 @printers.node_printer(ast.RangeSubselect, override=True)
-def range_subselect(node: ast.RangeSubselect, output: stream.RawStream) -> None:
+def range_subselect(node: ast.RangeSubselect, output: formatter.PrinterOutput) -> None:
     """Printer for RangeSubselect."""
     if node.lateral:
         output.write("LATERAL")

--- a/src/pgrubic/formatters/dml/typecast.py
+++ b/src/pgrubic/formatters/dml/typecast.py
@@ -10,7 +10,7 @@ NATIVE_CAST_OPERATOR = "::"
 
 def native_cast_argument_needs_parentheses(
     node: ast.Node,
-    output: formatter.RawStream | formatter.IndentedStream,
+    output: formatter.PrinterOutput,
 ) -> bool:
     """Check whether a native cast argument needs parentheses."""
     if isinstance(node, ast.FuncCall):
@@ -43,7 +43,7 @@ def is_char_type(node: ast.Node) -> bool:
 
 def is_native_cast(
     node: ast.TypeCast,
-    output: formatter.RawStream | formatter.IndentedStream,
+    output: formatter.PrinterOutput,
 ) -> bool:
     """Check whether a cast originated from PostgreSQL's ``::`` syntax."""
     native_cast_operator_length = len(NATIVE_CAST_OPERATOR)
@@ -71,7 +71,7 @@ def char_has_default_length(typmods: tuple[ast.Node, ...]) -> bool:
 @printers.node_printer(ast.TypeCast, override=True)
 def type_cast(
     node: ast.TypeCast,
-    output: formatter.RawStream | formatter.IndentedStream,
+    output: formatter.PrinterOutput,
 ) -> None:
     """Printer for TypeCast."""
     # An unmodified CHAR typed literal is not interchangeable with an implicit

--- a/src/pgrubic/formatters/dml/update.py
+++ b/src/pgrubic/formatters/dml/update.py
@@ -1,10 +1,12 @@
 """Formatter for UPDATE statements."""
 
-from pglast import ast, stream, printers
+from pglast import ast, printers
+
+from pgrubic.core import formatter
 
 
 @printers.node_printer(ast.UpdateStmt, override=True)
-def update_stmt(node: ast.UpdateStmt, output: stream.RawStream) -> None:
+def update_stmt(node: ast.UpdateStmt, output: formatter.PrinterOutput) -> None:
     """Printer for UpdateStmt."""
     with output.push_indent():
         if node.withClause:

--- a/tests/fixtures/rules/inline.yml
+++ b/tests/fixtures/rules/inline.yml
@@ -105,6 +105,24 @@ test_fail_inline_sql_in_plpgsql_function_in_function_call:
     $$,
     '{global}'::text[]);
 
+test_fail_inline_create_table_with_storage_options_in_function_call:
+  sql_fail: |
+    SELECT pglogical.replicate_ddl_command(
+    $$
+        CREATE TABLE events (created_at timestamp)
+        WITH (fillfactor = 90);
+    $$,
+    '{global}'::text[]);
+
+test_fail_inline_create_index_in_function_call:
+  sql_fail: |
+    SELECT pglogical.replicate_ddl_command(
+    $$
+        CREATE INDEX events_created_at_idx ON events (created_at, processed_at);
+        ALTER TABLE events ADD COLUMN processed_at timestamp;
+    $$,
+    '{global}'::text[]);
+
 test_pass_inline_sql_in_plpgsql_block_in_function_call:
   sql_pass: |
     SELECT pglogical.replicate_ddl_command(

--- a/tests/fixtures/rules/inline.yml
+++ b/tests/fixtures/rules/inline.yml
@@ -111,6 +111,9 @@ test_fail_inline_create_table_with_storage_options_in_function_call:
     $$
         CREATE TABLE events (created_at timestamp)
         WITH (fillfactor = 90);
+
+        CREATE TABLE events_2026 PARTITION OF events
+        FOR VALUES FROM ('2026-01-01') TO ('2027-01-01');
     $$,
     '{global}'::text[]);
 

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -59,6 +59,36 @@ def test_configured_streams(formatter: core.Formatter) -> None:
     assert indented_stream.config is formatter.config
 
 
+def test_create_raw_stream_factory(formatter: core.Formatter) -> None:
+    """Test the formatter creates fresh, consistently configured raw streams."""
+    first_stream = formatter.create_raw_stream()
+    second_stream = formatter.create_raw_stream()
+
+    assert first_stream is not second_stream
+    assert first_stream.config is formatter.config
+    assert (
+        first_stream.special_functions
+        is formatter.config.format.rewrite_function_calls_as_equivalent_syntax
+    )
+    assert (
+        first_stream.remove_pg_catalog_from_functions
+        is formatter.config.format.remove_pg_catalog_from_functions
+    )
+
+
+def test_raw_stream_supports_custom_printers(formatter: core.Formatter) -> None:
+    """Test custom printers support raw stream rendering."""
+    assert formatter.create_raw_stream()("CREATE INDEX idx ON tbl (value)") == (
+        "CREATE INDEX idx ON tbl (value)"
+    )
+    assert (
+        formatter.create_raw_stream()(
+            "CREATE TABLE tbl (value integer) WITH (fillfactor = 90)",
+        )
+        == "CREATE TABLE tbl (value integer) WITH (fillfactor = 90)"
+    )
+
+
 def test_concatenate_nodes_with_type_cast(formatter: core.Formatter) -> None:
     """Test raw node concatenation uses the configured type-casting style."""
     with conftest.update_config(


### PR DESCRIPTION
## Background and Motivation
<!-- Why is this change needed? What problem does it solve? -->
pgrubic registers custom pglast printers that expect pgrubic-specific stream capabilities and configuration. Inline SQL extraction previously rendered AST nodes using pglast’s plain RawStream. This became unsafe when inline SQL contained statements such as `CREATE TABLE` or `CREATE INDEX`, because their custom printers require methods and configuration unavailable on the upstream stream.

## Summary of Changes
<!-- High-level overview of what was changed. -->
- Standardized custom printer output typing with PrinterOutput, covering pgrubic’s RawStream and IndentedStream.
- Added a formatter factory that creates fresh, consistently configured raw streams.
- Updated inline SQL extraction to use that factory instead of pglast’s RawStream.
- Made the inline visitor helper arguments explicitly keyword-only.
- Extended pgrubic’s RawStream with compact implementations of the helpers used by shared printers.
- Preserved required spacing before parenthesized lists in raw output.
- Updated all custom printer annotations to use the shared stream contract.
- Added coverage for inline CREATE TABLE, partition tables, storage options, and CREATE INDEX.
- Added regression tests confirming raw streams support the custom DDL printers.

## Type of change
<!-- Select the type of change. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Housekeeping (change that does not affect functionality)

## SQL Examples (if applicable)
<!-- Provide sample SQL to show before/after behavior of the linter/formatter. -->

```sql
-- Before
...

-- After
...
```

## Checklist
<!-- Checklist before requesting a review -->
- [ ] I have read and followed the [contributing guidelines](https://github.com/bolajiwahab/pgrubic/blob/main/docs/docs/contributing.md)
- [ ] I have checked that there are no other open [Pull Requests](https://github.com/bolajiwahab/pgrubic/pulls) for the same update/change
- [ ] I have performed a self-review of my code
- [ ] I have added/updated tests (positive + negative cases)
- [ ] I have updated documentation (if applicable)

## Closes / Fixes
<!-- Link issues using keywords: Closes #123, Fixes #456 -->

## Additional information
<!-- Provide any additional information that might be helpful to the reviewer in reviewing this pull request -->
