### PR TITLE
feat(config): support overrides from cli

### DIFF
--- a/docs/cli_docs_generator.py
+++ b/docs/cli_docs_generator.py
@@ -1,0 +1,48 @@
+"""Generate CLI documentation from Click command metadata."""
+
+import pathlib
+
+from click import testing
+
+from pgrubic import PACKAGE_NAME
+from pgrubic.__main__ import cli
+
+CLI_DOCUMENTATION = pathlib.Path.cwd() / "docs/docs/cli.md"
+EXIT_CODES_HEADING = "## Exit codes"
+
+
+def _render_help(*args: str) -> str:
+    """Render plain CLI help for a command."""
+    result = testing.CliRunner().invoke(
+        cli,
+        [*args, "--help"],
+        prog_name=PACKAGE_NAME,
+    )
+
+    if result.exception:
+        raise result.exception
+
+    return "\n".join(line.rstrip() for line in result.output.rstrip().splitlines())
+
+
+def main() -> None:
+    """Generate CLI reference while preserving the exit-code documentation."""
+    current_documentation = CLI_DOCUMENTATION.read_text()
+    _, separator, exit_codes = current_documentation.partition(EXIT_CODES_HEADING)
+
+    if not separator:
+        msg = f"Missing {EXIT_CODES_HEADING!r} section in {CLI_DOCUMENTATION}"
+        raise ValueError(msg)
+
+    sections = [
+        "# Command line interface",
+        f"## {PACKAGE_NAME}\n\n```text\n{_render_help()}\n```",
+        f"## lint\n\n```text\n{_render_help('lint')}\n```",
+        f"## format\n\n```text\n{_render_help('format')}\n```",
+        f"{EXIT_CODES_HEADING}{exit_codes.rstrip()}",
+    ]
+    CLI_DOCUMENTATION.write_text("\n\n".join(sections) + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/docs/cli.md
+++ b/docs/docs/cli.md
@@ -2,85 +2,87 @@
 
 ## pgrubic
 
-  PostgreSQL linter and formatter for schema migrations and design
-  best practices.
+```text
+Pgrubic: A PostgreSQL linter and formatter for schema migrations and design best
+practices.
 
-### **Options**
+Usage: pgrubic [OPTIONS] COMMAND [ARGS]...
 
-#### **--version**
+Commands:
+  format  Run the SQL formatter on the given files or directories.
+  lint    Run the SQL linter on the given files or directories.
 
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Show the version and exit.
+Options:
+  -v, --version  Show the version and exit.
+  -h, --help     Show this message and exit.
 
-  Examples:
+Configuration overrides:
+  Pass a TOML `<KEY> = <VALUE>` pair. May be repeated.
+    --config "lint.target-postgres-version = 17"
+    --config 'format.type-casting-style = "native"'
 
-     pgrubic lint
+Examples:
+  pgrubic lint .
+  pgrubic lint --fix migrations/
+  pgrubic format schema.sql
+  pgrubic format --check migrations/
+```
 
-     pgrubic lint .
+## lint
 
-     pgrubic lint *.sql
+```text
+Run the SQL linter on the given files or directories.
 
-     pgrubic lint example.sql
+Usage: pgrubic lint [OPTIONS] [SOURCES]...
 
-     pgrubic format file.sql
+Options:
+  --fix                          Apply fixes to resolve lint violations.
+  --ignore-noqa                  Ignore inline `-- noqa` directives.
+  --add-file-level-general-noqa  Add `-- pgrubic: noqa` to the beginning of each
+                                 SQL file, causing the entire file to be ignored
+                                 by the linter.
+  --generate-lint-report         Generate a lint report.
+  --config <CONFIG_OPTION>       A TOML `<KEY> = <VALUE>` pair overriding a
+                                 configuration option. May be repeated. Command-
+                                 line overrides always take precedence over
+                                 configuration files.
 
-     pgrubic format migrations/
+                                 Examples:
+                                   --config "lint.target-postgres-version = 17"
+                                   --config 'format.type-casting-style = "native"'
+  --verbose                      Enable verbose logging.
+  --workers INTEGER              Number of workers to use. Defaults to the
+                                 number of CPUs or the value of PGRUBIC_WORKERS.
+  -v, --version                  Show the version and exit.
+  -h, --help                     Show this message and exit.
+```
 
-## **lint**
+## format
 
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Lint SQL files.
+```text
+Run the SQL formatter on the given files or directories.
 
-### **Options**
+Usage: pgrubic format [OPTIONS] [SOURCES]...
 
-#### **--fix**
+Options:
+  --check                   Check if any files would be reformatted.
+  --diff                    Report the difference between the current file and
+                            what the formatted file would look like.
+  --no-cache                Disable cache reads.
+  --config <CONFIG_OPTION>  A TOML `<KEY> = <VALUE>` pair overriding a
+                            configuration option. May be repeated. Command-line
+                            overrides always take precedence over configuration
+                            files.
 
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Fix lint violations automatically.
-
-#### **--ignore-noqa**
-
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Whether to ignore noqa directives.
-
-#### **--add-file-level-general-noqa**
-
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Whether to add file-level noqa directives.
-
-#### **--generate-lint-report**
-
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Whether to generate a lint report.
-
-#### **--verbose**
-
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Enable verbose logging.
-
-#### **--workers**
-
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Number of workers to use.
-
-## **format**
-
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Format SQL files.
-
-### **Options**
-
-#### **--check**
-
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Check if any files would have been modified.
-
-#### **--diff**
-
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Report the difference between the current file and how the
-formatted file would look like.
-
-#### **--no-cache**
-
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Whether to read the cache.
-
-#### **--verbose**
-
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Enable verbose logging.
-
-#### **--workers**
-
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Number of workers to use.
+                            Examples:
+                              --config "lint.target-postgres-version = 17"
+                              --config 'format.type-casting-style = "native"'
+  --verbose                 Enable verbose logging.
+  --workers INTEGER         Number of workers to use. Defaults to the number of
+                            CPUs or the value of PGRUBIC_WORKERS.
+  -v, --version             Show the version and exit.
+  -h, --help                Show this message and exit.
+```
 
 ## Exit codes
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -266,6 +266,7 @@ legacy_tox_ini = """
         # We need to build the project in order to generate the docs.
         # Hence it fails with import errors.
         pip install .
+        python docs/cli_docs_generator.py
         python docs/rule_docs_generator.py
         python docs/settings_doc_generator.py
         python docs/rule_metadata_generator.py

--- a/src/pgrubic/__main__.py
+++ b/src/pgrubic/__main__.py
@@ -8,64 +8,88 @@ import pathlib
 import multiprocessing
 from collections import abc
 
+import toml
 import click
 from rich.syntax import Syntax
 from rich.console import Console
 
-from pgrubic import PACKAGE_NAME, DEFAULT_WORKERS, WORKERS_ENVIRONMENT_VARIABLE, core
+from pgrubic import DEFAULT_WORKERS, WORKERS_ENVIRONMENT_VARIABLE, core, cli_help
 from pgrubic.core import noqa, errors
 
 
 def common_options[T](func: abc.Callable[..., T]) -> abc.Callable[..., T]:
     """Decorator to add common options to each subcommand."""
-    func = click.version_option()(func)
-    func = click.option("--workers", type=int, help="Number of workers to use.")(func)
-    return click.option("--verbose", is_flag=True, help="Enable verbose logging.")(func)
+    func = click.version_option(None, "-v", "--version")(func)
+    func = click.option(
+        "--workers",
+        type=int,
+        help=f"Number of workers to use. Defaults to the number of CPUs or the value of {WORKERS_ENVIRONMENT_VARIABLE}.",  # noqa: E501
+    )(func)
+    func = click.option("--verbose", is_flag=True, help="Enable verbose logging.")(func)
+    return click.option(
+        "--config",
+        "config_overrides",
+        multiple=True,
+        metavar="<CONFIG_OPTION>",
+        help=cli_help.CONFIG_OVERRIDE_HELP,
+    )(func)
+
+
+def _parse_config_overrides(
+    config_overrides: tuple[str, ...],
+) -> dict[str, object]:
+    """Parse CLI configuration overrides as TOML key-value pairs."""
+    if not config_overrides:
+        return {}
+
+    config_override = "\n".join(config_overrides)
+
+    try:
+        return dict(toml.loads(config_override))
+    except toml.decoder.TomlDecodeError as error:
+        msg = f'Error parsing configuration override "{config_override}"'
+        raise errors.ConfigParseError(msg) from error
 
 
 @click.group(
+    cls=cli_help.Group,
     context_settings={"help_option_names": ["-h", "--help"]},
-    epilog=f"""
-Examples:{noqa.NEW_LINE}
-   {PACKAGE_NAME} lint{noqa.NEW_LINE}
-   {PACKAGE_NAME} lint .{noqa.NEW_LINE}
-   {PACKAGE_NAME} lint *.sql{noqa.NEW_LINE}
-   {PACKAGE_NAME} lint example.sql{noqa.NEW_LINE}
-   {PACKAGE_NAME} format file.sql{noqa.NEW_LINE}
-   {PACKAGE_NAME} format migrations/{noqa.NEW_LINE}
-""",
+    epilog=cli_help.ROOT_EPILOG,
 )
-@click.version_option()
+@click.version_option(None, "-v", "--version")
 def cli() -> None:
-    """Pgrubic: PostgreSQL linter and formatter for schema migrations
+    """Pgrubic: A PostgreSQL linter and formatter for schema migrations
     and design best practices.
     """
 
 
-@cli.command(name="lint")
+@cli.command(
+    name="lint",
+    help="Run the SQL linter on the given files or directories.",
+)
 @click.option(
     "--fix",
     is_flag=True,
     default=False,
-    help="Fix lint violations automatically.",
+    help="Apply fixes to resolve lint violations.",
 )
 @click.option(
     "--ignore-noqa",
     is_flag=True,
     default=False,
-    help="Whether to ignore noqa directives.",
+    help="Ignore inline `-- noqa` directives.",
 )
 @click.option(
     "--add-file-level-general-noqa",
     is_flag=True,
     default=False,
-    help="Whether to add file-level noqa directives.",
+    help="Add `-- pgrubic: noqa` to the beginning of each SQL file, causing the entire file to be ignored by the linter.",  # noqa: E501
 )
 @click.option(
     "--generate-lint-report",
     is_flag=True,
     default=False,
-    help="Whether to generate a lint report.",
+    help="Generate a lint report.",
 )
 @common_options
 @click.argument("sources", nargs=-1, type=click.Path(exists=True, path_type=pathlib.Path))  # type: ignore [type-var]
@@ -76,6 +100,7 @@ def lint(  # noqa: C901, PLR0912, PLR0913, PLR0915
     ignore_noqa: bool,
     add_file_level_general_noqa: bool,
     generate_lint_report: bool,
+    config_overrides: tuple[str, ...],
     workers: int,
     verbose: bool,
 ) -> None:
@@ -93,6 +118,8 @@ def lint(  # noqa: C901, PLR0912, PLR0913, PLR0915
         Whether to add file-level noqa directives.
     generate_lint_report: bool
         Whether to generate a lint report.
+    config_overrides: tuple[str, ...]
+        TOML key-value pairs overriding configuration options.
     workers: int
         Number of workers to use.
     verbose: bool
@@ -106,7 +133,9 @@ def lint(  # noqa: C901, PLR0912, PLR0913, PLR0915
     core.logger.setLevel(logging.INFO if verbose else logging.WARNING)
 
     try:
-        config = core.parse_config()
+        config = core.parse_config(
+            overrides=_parse_config_overrides(config_overrides),
+        )
     except errors.MissingConfigError as error:
         sys.stderr.write(f"{error}{noqa.NEW_LINE}")
         sys.exit(1)
@@ -242,26 +271,27 @@ def lint(  # noqa: C901, PLR0912, PLR0913, PLR0915
         sys.stdout.write(f"All checks passed!{noqa.NEW_LINE}")
 
 
-@cli.command(name="format")
+@cli.command(
+    name="format",
+    help="Run the SQL formatter on the given files or directories.",
+)
 @click.option(
     "--check",
     is_flag=True,
     default=False,
-    help="Check if any files would have been modified.",
+    help="Check if any files would be reformatted.",
 )
 @click.option(
     "--diff",
     is_flag=True,
     default=False,
-    help="""
-    Report the difference between the current file and
-    how the formatted file would look like.""",
+    help="Report the difference between the current file and what the formatted file would look like.",  # noqa: E501
 )
 @click.option(
     "--no-cache",
     is_flag=True,
     default=False,
-    help="Whether to read the cache.",
+    help="Disable cache reads.",
 )
 @common_options
 @click.argument("sources", nargs=-1, type=click.Path(exists=True, path_type=pathlib.Path))  # type: ignore [type-var]
@@ -271,6 +301,7 @@ def format_sources(  # noqa: C901, PLR0912, PLR0913, PLR0915
     check: bool,
     diff: bool,
     no_cache: bool,
+    config_overrides: tuple[str, ...],
     workers: int,
     verbose: bool,
 ) -> None:
@@ -281,12 +312,14 @@ def format_sources(  # noqa: C901, PLR0912, PLR0913, PLR0915
     sources: tuple[pathlib.Path, ...]
         List of sources to format.
     check: bool
-        Check if any files would have been modified.
+        Check if any files would be reformatted.
     diff: bool
         Report the difference between the current file and
         how the formatted file would look like.
     no_cache: bool
         Whether to read the cache.
+    config_overrides: tuple[str, ...]
+        TOML key-value pairs overriding configuration options.
     workers: int
         Number of workers to use.
     verbose: bool
@@ -302,7 +335,9 @@ def format_sources(  # noqa: C901, PLR0912, PLR0913, PLR0915
     console = Console()
 
     try:
-        config = core.parse_config()
+        config = core.parse_config(
+            overrides=_parse_config_overrides(config_overrides),
+        )
     except errors.MissingConfigError as error:
         sys.stderr.write(f"{error}{noqa.NEW_LINE}")
         sys.exit(1)

--- a/src/pgrubic/cli_help.py
+++ b/src/pgrubic/cli_help.py
@@ -1,0 +1,138 @@
+"""CLI help presentation."""
+
+import inspect
+from collections import abc
+
+import click
+
+from pgrubic import PACKAGE_NAME
+
+CONFIG_OVERRIDE_HELP = """A TOML `<KEY> = <VALUE>` pair overriding a configuration option.
+May be repeated. Command-line overrides always take precedence over configuration
+files.
+
+\b
+Examples:
+  --config "lint.target-postgres-version = 17"
+  --config 'format.type-casting-style = "native"'
+"""
+
+ROOT_EPILOG = f"""\b
+{click.style("Configuration overrides:", fg="cyan", bold=True)}
+  Pass a TOML `<KEY> = <VALUE>` pair. May be repeated.
+    --config "lint.target-postgres-version = 17"
+    --config 'format.type-casting-style = "native"'
+
+\b
+{click.style("Examples:", fg="cyan", bold=True)}
+  {PACKAGE_NAME} lint .
+  {PACKAGE_NAME} lint --fix migrations/
+  {PACKAGE_NAME} format schema.sql
+  {PACKAGE_NAME} format --check migrations/
+"""
+
+
+class HelpFormatter(click.HelpFormatter):
+    """Render CLI help with terminal-aware colors."""
+
+    def write_usage(
+        self,
+        prog: str,
+        args: str = "",
+        prefix: str | None = None,
+    ) -> None:
+        """Write a usage line with a colored heading and command."""
+        if prefix is None:
+            prefix = f"{click.style('Usage:', fg='cyan', bold=True)} "
+        super().write_usage(
+            click.style(prog, fg="green", bold=True),
+            click.style(args, fg="green", bold=True),
+            prefix,
+        )
+
+    def write_heading(self, heading: str) -> None:
+        """Write a colored section heading."""
+        super().write_heading(click.style(heading, fg="cyan", bold=True))
+
+    def write_dl(
+        self,
+        rows: abc.Iterable[abc.Iterable[str]],
+        col_max: int = 30,
+        col_spacing: int = 2,
+    ) -> None:
+        """Write a definition list with colored options and commands."""
+        super().write_dl(
+            ((click.style(term, fg="green"), description) for term, description in rows),
+            col_max,
+            col_spacing,
+        )
+
+
+class Context(click.Context):
+    """Click context using pgrubic's help formatter."""
+
+    formatter_class = HelpFormatter
+
+
+def _format_help(
+    command: click.Command,
+    ctx: click.Context,
+    formatter: click.HelpFormatter,
+) -> None:
+    """Write help with a flush-left description before usage."""
+    description = inspect.cleandoc(command.help or "").partition("\f")[0]
+    if description:
+        formatter.write_text(description)
+        formatter.write_paragraph()
+
+    command.format_usage(ctx, formatter)
+    command.format_options(ctx, formatter)
+    command.format_epilog(ctx, formatter)
+
+
+class Command(click.Command):
+    """Click command using pgrubic's context."""
+
+    context_class = Context
+
+    def format_help(
+        self,
+        ctx: click.Context,
+        formatter: click.HelpFormatter,
+    ) -> None:
+        """Write help with the description before usage, as Ruff does."""
+        _format_help(self, ctx, formatter)
+
+
+class Group(click.Group):
+    """Click group whose subcommands use pgrubic's help formatting."""
+
+    context_class = Context
+    command_class = Command
+
+    def format_help(
+        self,
+        ctx: click.Context,
+        formatter: click.HelpFormatter,
+    ) -> None:
+        """Write help with the description before usage, as Ruff does."""
+        _format_help(self, ctx, formatter)
+
+    def format_options(
+        self,
+        ctx: click.Context,
+        formatter: click.HelpFormatter,
+    ) -> None:
+        """Write commands before root options."""
+        self.format_commands(ctx, formatter)
+        click.Command.format_options(self, ctx, formatter)
+
+    def format_epilog(
+        self,
+        ctx: click.Context,
+        formatter: click.HelpFormatter,
+    ) -> None:
+        """Write root help examples without indenting their headings."""
+        if self.epilog:
+            formatter.write_paragraph()
+            formatter.write_text(inspect.cleandoc(self.epilog))

--- a/src/pgrubic/core/config.py
+++ b/src/pgrubic/core/config.py
@@ -1089,6 +1089,24 @@ def _parse_type_casting_style(value: object) -> enums.TypeCastingStyle:
     raise errors.InvalidConfigValueError(msg) from None
 
 
+def _validate_config_section(
+    *,
+    config: dict[str, typing.Any],
+    key: str,
+) -> dict[str, typing.Any]:
+    """Validate and return a configuration section."""
+    value = config[key]
+
+    if not isinstance(value, dict):
+        msg = (
+            f'Invalid config value for key "{key}": "{value}". '
+            "Expected a configuration section."
+        )
+        raise errors.InvalidConfigValueError(msg)
+
+    return value
+
+
 def parse_config(overrides: dict[str, typing.Any] | None = None) -> Config:
     """Parse config.
 
@@ -1113,10 +1131,11 @@ def parse_config(overrides: dict[str, typing.Any] | None = None) -> Config:
         overrides = {}
 
     merged_config = _merge_config(overrides=overrides)
-    config_lint = merged_config["lint"]
-    config_format = merged_config["format"]
 
     try:
+        config_lint = _validate_config_section(config=merged_config, key="lint")
+        config_format = _validate_config_section(config=merged_config, key="format")
+
         return Config(
             cache_dir=pathlib.Path(merged_config["cache-dir"]),
             include=merged_config["include"],

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -762,6 +762,28 @@ def test_cli_invalid_config_override(
     )
 
 
+@pytest.mark.parametrize("command", ["lint", "format"])
+def test_cli_invalid_config_override_section(
+    command: str,
+    tmp_path: pathlib.Path,
+) -> None:
+    """Test structurally invalid CLI configuration overrides."""
+    source_file = tmp_path / TEST_FILE
+    source_file.write_text("SELECT 1;")
+
+    result = testing.CliRunner().invoke(
+        cli,
+        [command, "--config", "format = 1", str(source_file)],
+    )
+
+    assert result.exit_code == 1
+    assert result.output == (
+        'Invalid config value for key "format": "1". '
+        "Expected a configuration section."
+        f"{noqa.NEW_LINE}"
+    )
+
+
 def test_cli_format_config_file_from_environment_variable_not_found_error(
     tmp_path: pathlib.Path,
 ) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,6 +3,7 @@
 import pathlib
 from unittest.mock import patch
 
+import click
 import pytest
 from click import testing
 
@@ -14,6 +15,57 @@ from pgrubic import (
 )
 from pgrubic.core import noqa, config, linter
 from pgrubic.__main__ import cli
+
+
+@pytest.mark.parametrize(
+    ("args", "description", "usage_command"),
+    [
+        (["--help"], "Pgrubic: A PostgreSQL linter", "cli"),
+        (
+            ["lint", "--help"],
+            "Run the SQL linter on the given files or directories.",
+            "cli lint",
+        ),
+    ],
+)
+def test_cli_help_colors(
+    args: list[str],
+    description: str,
+    usage_command: str,
+) -> None:
+    """Test help colors are emitted only when color output is enabled."""
+    runner = testing.CliRunner()
+
+    colored_result = runner.invoke(cli, args, color=True)
+    plain_result = runner.invoke(cli, args)
+
+    assert colored_result.exit_code == 0
+    assert "\x1b[" in colored_result.output
+    assert click.style(usage_command, fg="green", bold=True) in colored_result.output
+    assert plain_result.exit_code == 0
+    assert "\x1b[" not in plain_result.output
+    assert plain_result.output.index(description) < plain_result.output.index("Usage:")
+    assert "Parameters:" not in plain_result.output
+    assert '--config "lint.target-postgres-version = 17"' in plain_result.output
+    if args == ["lint", "--help"]:
+        normalized_output = " ".join(plain_result.output.split())
+        assert "Ignore inline `-- noqa` directives." in normalized_output
+        assert "causing the entire file to be ignored by the linter." in normalized_output
+    if args == ["--help"]:
+        assert plain_result.output.index("\nCommands:\n") < plain_result.output.index(
+            "\nOptions:\n",
+        )
+        assert "\nConfiguration overrides:\n" in plain_result.output
+        assert "\nExamples:\n" in plain_result.output
+
+
+@pytest.mark.parametrize("args", [["-v"], ["lint", "-v"]])
+def test_cli_short_version_option(args: list[str]) -> None:
+    """Test the short version option on the root and subcommands."""
+    result = testing.CliRunner().invoke(cli, args)
+
+    assert result.exit_code == 0
+    assert " version " in result.output
 
 
 def test_cli_lint_file(tmp_path: pathlib.Path) -> None:
@@ -86,6 +138,31 @@ def test_cli_lint_complete_fix(tmp_path: pathlib.Path) -> None:
     result = runner.invoke(cli, ["lint", str(file_fail), "--fix"])
 
     assert result.exit_code == 0
+
+
+def test_cli_lint_config_override(
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test overriding lint configuration from the CLI."""
+    runner = testing.CliRunner()
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / config.CONFIG_FILE).write_text(
+        """
+[lint]
+fix = false
+""",
+    )
+    source_file = tmp_path / TEST_FILE
+    source_file.write_text("SELECT a = NULL;")
+
+    result = runner.invoke(
+        cli,
+        ["lint", "--config", "lint.fix = true", str(source_file)],
+    )
+
+    assert result.exit_code == 0
+    assert source_file.read_text() == f"SELECT a IS NULL;{noqa.NEW_LINE}"
 
 
 def test_cli_lint_with_add_file_level_general_noqa(tmp_path: pathlib.Path) -> None:
@@ -629,6 +706,60 @@ def test_cli_format_missing_config_error(tmp_path: pathlib.Path) -> None:
         assert result.output == f"Missing config key: data-type{noqa.NEW_LINE}"
 
         assert result.exit_code == 1
+
+
+def test_cli_format_config_overrides(
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test overriding multiple format options from the CLI."""
+    runner = testing.CliRunner()
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / config.CONFIG_FILE).write_text(
+        """
+[format]
+uppercase-keywords = true
+type-casting-style = "literal"
+""",
+    )
+    source_file = tmp_path / TEST_FILE
+    source_file.write_text("SELECT CAST(value AS text);")
+
+    result = runner.invoke(
+        cli,
+        [
+            "format",
+            "--config",
+            "format.uppercase-keywords = false",
+            "--config",
+            'format.type-casting-style = "native"',
+            str(source_file),
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert source_file.read_text() == f"select value::text;{noqa.NEW_LINE}"
+
+
+@pytest.mark.parametrize("command", ["lint", "format"])
+def test_cli_invalid_config_override(
+    command: str,
+    tmp_path: pathlib.Path,
+) -> None:
+    """Test invalid CLI configuration overrides."""
+    runner = testing.CliRunner()
+    source_file = tmp_path / TEST_FILE
+    source_file.write_text("SELECT 1;")
+
+    result = runner.invoke(
+        cli,
+        [command, "--config", "format.uppercase-keywords", str(source_file)],
+    )
+
+    assert result.exit_code == 1
+    assert result.output == (
+        f'Error parsing configuration override "format.uppercase-keywords"{noqa.NEW_LINE}'
+    )
 
 
 def test_cli_format_config_file_from_environment_variable_not_found_error(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -182,6 +182,18 @@ def test_invalid_non_string_type_casting_style_error(tmp_path: pathlib.Path) -> 
     )
 
 
+@pytest.mark.parametrize("section", ["lint", "format"])
+def test_invalid_config_section(section: str) -> None:
+    """Test configuration sections must be TOML tables."""
+    with pytest.raises(errors.InvalidConfigValueError) as excinfo:
+        config.parse_config(overrides={section: 1})
+
+    assert excinfo.value.args[0] == (
+        f'Invalid config value for key "{section}": "1". '
+        "Expected a configuration section."
+    )
+
+
 def test_config_file_from_environment_variable_not_found_error() -> None:
     """Test config from environment variable not found error."""
     with patch.dict(


### PR DESCRIPTION
## Background and Motivation
<!-- Why is this change needed? What problem does it solve? -->
Adds repeatable TOML configuration overrides to `lint` and `format`, alongside updated help/version output and CLI tests.
## Summary of Changes
<!-- High-level overview of what was changed. -->
- Adds `--config` override parsing and integration.
- Validate `lint` and `format` config sections
- Adds custom colored help formatting and version options.
- Adds tests for overrides, errors, help, and version behavior.
## Type of change
<!-- Select the type of change. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Housekeeping (change that does not affect functionality)

## SQL Examples (if applicable)
<!-- Provide sample SQL to show before/after behavior of the linter/formatter. -->

```sql
-- Before
...

-- After
...
```

## Checklist
<!-- Checklist before requesting a review -->
- [x] I have read and followed the [contributing guidelines](https://github.com/bolajiwahab/pgrubic/blob/main/docs/docs/contributing.md)
- [x] I have checked that there are no other open [Pull Requests](https://github.com/bolajiwahab/pgrubic/pulls) for the same update/change
- [x] I have performed a self-review of my code
- [x] I have added/updated tests (positive + negative cases)
- [x] I have updated documentation (if applicable)

## Closes / Fixes
<!-- Link issues using keywords: Closes #123, Fixes #456 -->

## Additional information
<!-- Provide any additional information that might be helpful to the reviewer in reviewing this pull request -->
