### PR TITLE
fix(config): replace list values when merging configuration

### DIFF
--- a/src/pgrubic/core/config.py
+++ b/src/pgrubic/core/config.py
@@ -7,7 +7,7 @@ import pathlib
 import dataclasses
 
 import toml
-from deepmerge import always_merger
+from deepmerge import merger
 
 from pgrubic import PACKAGE_NAME
 from pgrubic.core import enums, errors
@@ -21,6 +21,12 @@ DEFAULT_CONFIG: typing.Final[pathlib.Path] = (
 
 CONFIG_PATH_ENVIRONMENT_VARIABLE: typing.Final[str] = (
     f"{PACKAGE_NAME.upper()}_CONFIG_PATH"
+)
+
+_CONFIG_MERGER: typing.Final[merger.Merger] = merger.Merger(
+    [(dict, ["merge"]), (list, ["override"])],
+    ["override"],
+    ["override"],
 )
 
 
@@ -1002,12 +1008,11 @@ def _merge_config(*, overrides: dict[str, typing.Any]) -> dict[str, typing.Any]:
     dict[str, typing.Any]
         The merged config.
     """
-    return dict(
-        always_merger.merge(
-            _load_default_config(),
-            always_merger.merge(_load_user_config(), overrides),
-        ),
+    merged_config = _CONFIG_MERGER.merge(
+        _load_default_config(),
+        _load_user_config(),
     )
+    return dict(_CONFIG_MERGER.merge(merged_config, overrides))
 
 
 def _get_config_file_absolute_path(

--- a/src/pgrubic/core/config.py
+++ b/src/pgrubic/core/config.py
@@ -24,9 +24,9 @@ CONFIG_PATH_ENVIRONMENT_VARIABLE: typing.Final[str] = (
 )
 
 _CONFIG_MERGER: typing.Final[merger.Merger] = merger.Merger(
-    [(dict, ["merge"]), (list, ["override"])],
-    ["override"],
-    ["override"],
+    type_strategies=[(dict, ["merge"]), (list, ["override"])],
+    fallback_strategies=["override"],
+    type_conflict_strategies=["override"],
 )
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,6 +3,7 @@
 import pathlib
 from unittest.mock import patch
 
+import toml
 import pytest
 
 from tests import conftest
@@ -239,3 +240,45 @@ def test_config_user_overrides(tmp_path: pathlib.Path) -> None:
     ):
         parsed_config = config.parse_config(overrides={"lint": {"fix": True}})
         assert parsed_config.lint.fix is True
+
+
+def test_user_config_list_replaces_default(tmp_path: pathlib.Path) -> None:
+    """Test user-configured lists replace default lists."""
+    default_config = dict(toml.load(config.DEFAULT_CONFIG))
+    default_config["lint"]["ignore"] = ["TP001"]
+    default_config_file = tmp_path / "default.toml"
+    default_config_file.write_text(toml.dumps(default_config))
+
+    config_directory = tmp_path / "config"
+    config_directory.mkdir()
+    (config_directory / config.CONFIG_FILE).write_text(
+        '[lint]\nignore = ["TP002"]\n',
+    )
+
+    with (
+        patch.object(config, "DEFAULT_CONFIG", default_config_file),
+        patch.dict(
+            "os.environ",
+            {config.CONFIG_PATH_ENVIRONMENT_VARIABLE: str(config_directory)},
+        ),
+    ):
+        parsed_config = config.parse_config()
+
+    assert parsed_config.lint.ignore == ["TP002"]
+
+
+def test_override_list_replaces_user_config(tmp_path: pathlib.Path) -> None:
+    """Test override lists replace user-configured lists."""
+    (tmp_path / config.CONFIG_FILE).write_text(
+        '[lint]\nignore = ["TP001"]\n',
+    )
+
+    with patch.dict(
+        "os.environ",
+        {config.CONFIG_PATH_ENVIRONMENT_VARIABLE: str(tmp_path)},
+    ):
+        parsed_config = config.parse_config(
+            overrides={"lint": {"ignore": ["TP002"]}},
+        )
+
+    assert parsed_config.lint.ignore == ["TP002"]


### PR DESCRIPTION
## Background and Motivation
<!-- Why is this change needed? What problem does it solve? -->
Updates configuration merging so that list-valued settings are replaced (not concatenated) when combining default config, user config, and runtime overrides—making user intent for list options unambiguous and consistent across sources.
## Summary of Changes
<!-- High-level overview of what was changed. -->
**Changes:**
- Introduced a custom `deepmerge` merger strategy that merges dicts but **overrides lists** during config composition.
- Updated `_merge_config` to use the new merger for default + user + overrides.
- Added tests ensuring user list values replace defaults and override lists replace user config lists.

## Type of change
<!-- Select the type of change. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Housekeeping (change that does not affect functionality)

## SQL Examples (if applicable)
<!-- Provide sample SQL to show before/after behavior of the linter/formatter. -->

```sql
-- Before
...

-- After
...
```

## Checklist
<!-- Checklist before requesting a review -->
- [x] I have read and followed the [contributing guidelines](https://github.com/bolajiwahab/pgrubic/blob/main/docs/docs/contributing.md)
- [x] I have checked that there are no other open [Pull Requests](https://github.com/bolajiwahab/pgrubic/pulls) for the same update/change
- [x] I have performed a self-review of my code
- [x] I have added/updated tests (positive + negative cases)
- [ ] I have updated documentation (if applicable)

## Closes / Fixes
<!-- Link issues using keywords: Closes #123, Fixes #456 -->

## Additional information
<!-- Provide any additional information that might be helpful to the reviewer in reviewing this pull request -->
