### PR TITLE
fix(formatter): honor configured formatting in function printers

### DIFF
--- a/src/pgrubic/formatters/ddl/function.py
+++ b/src/pgrubic/formatters/ddl/function.py
@@ -3,9 +3,7 @@
 
 from pglast import ast, enums, printers
 
-from pgrubic.core import Formatter, noqa, config, formatter
-
-_config: config.Config = config.parse_config()
+from pgrubic.core import Formatter, noqa, formatter
 
 
 @printers.node_printer(ast.CreateFunctionStmt, override=True)
@@ -103,14 +101,16 @@ def create_function_stmt(
                     for i, stmt in enumerate(node.sql_body[0]):
                         output.print_node(stmt)
 
-                        if not _config.format.new_line_before_semicolon:
+                        if not output.config.format.new_line_before_semicolon:
                             output.write(noqa.SEMI_COLON)
                         else:  # pragma: no cover
                             output.write(noqa.NEW_LINE + noqa.SEMI_COLON)
 
                         # Add newline until the last statement
                         if i < len(node.sql_body[0]) - 1:
-                            for _ in range(_config.format.lines_between_statements + 1):
+                            for _ in range(
+                                output.config.format.lines_between_statements + 1,
+                            ):
                                 output.newline()
 
             output.newline()
@@ -178,7 +178,7 @@ def create_function_option(  # noqa: PLR0911
             formatted_function_body, _ = Formatter.run(
                 source_code=function_body,
                 source_file="function_body",
-                config=_config,
+                config=output.config,
             )
 
             # indent the non empty lines of the formatted function body by 4 spaces

--- a/tests/fixtures/formatters/ddl/function.yml
+++ b/tests/fixtures/formatters/ddl/function.yml
@@ -55,6 +55,25 @@ create_sql_function_with_as:
           FROM tbl;
     $BODY$;
 
+create_sql_function_body_with_config:
+  sql: |
+    CREATE FUNCTION add(integer, integer) RETURNS integer
+    AS 'SELECT $1 + $2'
+    LANGUAGE SQL;
+  config:
+    format:
+      uppercase_keywords: false
+  expected: |
+    create function add (
+        integer
+      , integer
+    )
+    returns integer
+    language sql
+    as $BODY$
+        select $1 + $2;
+    $BODY$;
+
 create_plpgsql_conforming_style_function:
   sql: |
     CREATE FUNCTION add(a integer, b integer) RETURNS integer
@@ -195,7 +214,35 @@ create_sql_conforming_style_procedure:
         VALUES (b);
     END;
 
-create_sql_non_conforming_stype_procedure:
+create_sql_procedure_body_with_config:
+  sql: |
+    CREATE PROCEDURE insert_data(a integer, b integer)
+    LANGUAGE SQL
+    BEGIN ATOMIC
+      INSERT INTO tbl VALUES (a);
+      INSERT INTO tbl VALUES (b);
+    END;
+  config:
+    format:
+      new_line_before_semicolon: true
+      lines_between_statements: 0
+  expected: |
+    CREATE PROCEDURE insert_data (
+        a integer
+      , b integer
+    )
+    LANGUAGE SQL
+    BEGIN ATOMIC
+        INSERT INTO tbl
+        VALUES (a)
+    ;
+        INSERT INTO tbl
+        VALUES (b)
+    ;
+    END
+    ;
+
+create_sql_non_conforming_style_procedure:
   sql: |
     CREATE PROCEDURE insert_data(a integer, b integer)
     LANGUAGE SQL


### PR DESCRIPTION
## Background and Motivation
<!-- Why is this change needed? What problem does it solve? -->
This PR fixes configuration handling in the DDL function/procedure printers so that formatting decisions (e.g., keyword casing and semicolon placement) respect the *active* formatter configuration for the current run, rather than a globally parsed default.
## Summary of Changes
<!-- High-level overview of what was changed. -->
- Removed the module-level parsed config in the function/procedure printer and switched formatting decisions to use `output.config`.
- Passed `output.config` into `Formatter.run()` when formatting SQL function bodies so body formatting honors per-run settings.
- Added fixture coverage to validate config-driven behavior for SQL function bodies and SQL procedure statement/semicolon formatting.
## Type of change
<!-- Select the type of change. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Housekeeping (change that does not affect functionality)

## SQL Examples (if applicable)
<!-- Provide sample SQL to show before/after behavior of the linter/formatter. -->

```sql
-- Before
...

-- After
...
```

## Checklist
<!-- Checklist before requesting a review -->
- [x] I have read and followed the [contributing guidelines](https://github.com/bolajiwahab/pgrubic/blob/main/docs/docs/contributing.md)
- [x] I have checked that there are no other open [Pull Requests](https://github.com/bolajiwahab/pgrubic/pulls) for the same update/change
- [x] I have performed a self-review of my code
- [x] I have added/updated tests (positive + negative cases)
- [ ] I have updated documentation (if applicable)

## Closes / Fixes
<!-- Link issues using keywords: Closes #123, Fixes #456 -->

## Additional information
<!-- Provide any additional information that might be helpful to the reviewer in reviewing this pull request -->
