### PR TITLE
feat!: validate config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ dependencies = [
   "toml==0.10.2",
   "click==8.4.2",
   "rich==15.0.0",
+  "pydantic==2.13.4",
   "deepmerge==2.1.0",
   "msgpack==1.2.1",
   "GitPython==3.1.58",

--- a/src/pgrubic/core/config.py
+++ b/src/pgrubic/core/config.py
@@ -4,9 +4,9 @@ import os
 import typing
 import difflib
 import pathlib
-import dataclasses
 
 import toml
+from pydantic import BaseModel, ConfigDict, ValidationError, field_validator
 from deepmerge import merger
 
 from pgrubic import PACKAGE_NAME
@@ -30,8 +30,40 @@ _CONFIG_MERGER: typing.Final[merger.Merger] = merger.Merger(
 )
 
 
-@dataclasses.dataclass(kw_only=True, frozen=True)
-class DisallowedSchema:
+def _parse_type_casting_style(value: object) -> enums.TypeCastingStyle:
+    """Parse the configured type-casting style."""
+    valid_values = tuple(style.value for style in enums.TypeCastingStyle)
+
+    if isinstance(value, str):
+        try:
+            return enums.TypeCastingStyle(value)
+        except ValueError:
+            suggestion = difflib.get_close_matches(value, valid_values, n=1)
+    else:
+        suggestion = []
+
+    msg = ""
+    if suggestion:
+        msg += f'Did you mean "{suggestion[0]}"? '
+
+    valid_values_str = ", ".join(f'"{v}"' for v in valid_values)
+    msg += f"Expected one of: {valid_values_str}"
+
+    raise ValueError(msg)
+
+
+class BaseConfig(BaseModel):
+    """Base configuration model."""
+
+    model_config = ConfigDict(
+        alias_generator=lambda field_name: field_name.replace("_", "-"),
+        extra="forbid",
+        populate_by_name=True,
+        strict=True,
+    )
+
+
+class DisallowedSchema(BaseConfig):
     """Representation of disallowed schema."""
 
     name: str
@@ -39,8 +71,7 @@ class DisallowedSchema:
     use_instead: str
 
 
-@dataclasses.dataclass(kw_only=True, frozen=True)
-class DisallowedDataType:
+class DisallowedDataType(BaseConfig):
     """Representation of disallowed data type."""
 
     name: str
@@ -48,16 +79,14 @@ class DisallowedDataType:
     use_instead: str
 
 
-@dataclasses.dataclass(kw_only=True, frozen=True)
-class Column:
+class Column(BaseConfig):
     """Representation of column."""
 
     name: str
     data_type: str
 
 
-@dataclasses.dataclass(kw_only=True)
-class Lint:
+class Lint(BaseConfig):
     # fmt: off
     """
 ### **target-postgres-version**
@@ -541,9 +570,19 @@ regex-sequence = r"^[a-z0-9_]+$"
     regex_constraint_exclusion: str
     regex_sequence: str
 
+    @field_validator("additional_non_volatile_functions", mode="before")
+    @classmethod
+    def _parse_additional_non_volatile_functions(
+        cls,
+        value: object,
+    ) -> object:
+        """Store configured functions as an immutable set."""
+        if isinstance(value, list):
+            return frozenset(value)
+        return value
 
-@dataclasses.dataclass(kw_only=True)
-class Format:
+
+class Format(BaseConfig):
     # fmt: off
     """
 ### **include**
@@ -878,9 +917,13 @@ no-cache = true
     check: bool
     no_cache: bool
 
+    _validate_type_casting_style = field_validator(
+        "type_casting_style",
+        mode="before",
+    )(_parse_type_casting_style)
 
-@dataclasses.dataclass(kw_only=True)
-class Config:
+
+class Config(BaseConfig):
     # fmt: off
     """
 ### **cache-dir**
@@ -960,6 +1003,14 @@ respect-gitignore = false
 
     lint: Lint
     format: Format
+
+    @field_validator("cache_dir", mode="before")
+    @classmethod
+    def _parse_cache_dir(cls, value: object) -> object:
+        """Parse a configured cache path."""
+        if isinstance(value, str):
+            return pathlib.Path(value)
+        return value
 
 
 def _load_default_config() -> dict[str, typing.Any]:
@@ -1066,45 +1117,31 @@ def _get_config_file_absolute_path(
     return None  # pragma: no cover
 
 
-def _parse_type_casting_style(value: object) -> enums.TypeCastingStyle:
-    """Parse the configured type-casting style."""
-    valid_values = tuple(style.value for style in enums.TypeCastingStyle)
+def _config_key(location: tuple[str | int, ...]) -> str:
+    """Return a dotted configuration key from a validation location."""
+    return ".".join(str(part) for part in location)
 
-    if isinstance(value, str):
-        try:
-            return enums.TypeCastingStyle(value)
-        except ValueError:
-            suggestion = difflib.get_close_matches(value, valid_values, n=1)
+
+def _raise_config_validation_error(error: ValidationError) -> typing.NoReturn:
+    """Translate a Pydantic validation error to a public configuration error."""
+    detail = error.errors(include_url=False)[0]
+    key = _config_key(detail["loc"])
+
+    if detail["type"] == "missing":
+        msg = f"Missing config key: {key}"
+        raise errors.MissingConfigError(msg) from error
+
+    value = detail.get("input")
+    if detail["type"] == "model_type":
+        message = "Expected a configuration section"
+    elif detail["type"] == "value_error":
+        # Pydantic prefixes custom ValueError messages with "Value error, ";
+        # ctx["error"] holds the original, unprefixed message.
+        message = str(detail["ctx"]["error"])
     else:
-        suggestion = []
-
-    msg = f'Invalid config value for key "format.type-casting-style": "{value}".'
-
-    if suggestion:
-        msg += f' Did you mean "{suggestion[0]}"?'
-
-    valid_values_str = ", ".join(f'"{v}"' for v in valid_values)
-    msg += f" Expected one of: {valid_values_str}"
-
-    raise errors.InvalidConfigValueError(msg) from None
-
-
-def _validate_config_section(
-    *,
-    config: dict[str, typing.Any],
-    key: str,
-) -> dict[str, typing.Any]:
-    """Validate and return a configuration section."""
-    value = config[key]
-
-    if not isinstance(value, dict):
-        msg = (
-            f'Invalid config value for key "{key}": "{value}". '
-            "Expected a configuration section."
-        )
-        raise errors.InvalidConfigValueError(msg)
-
-    return value
+        message = detail["msg"]
+    msg = f'Invalid config value for key "{key}": "{value}". {message}.'
+    raise errors.InvalidConfigValueError(msg) from error
 
 
 def parse_config(overrides: dict[str, typing.Any] | None = None) -> Config:
@@ -1133,90 +1170,13 @@ def parse_config(overrides: dict[str, typing.Any] | None = None) -> Config:
     merged_config = _merge_config(overrides=overrides)
 
     try:
-        config_lint = _validate_config_section(config=merged_config, key="lint")
-        config_format = _validate_config_section(config=merged_config, key="format")
+        config = Config.model_validate(merged_config)
+    except ValidationError as error:
+        _raise_config_validation_error(error)
 
-        return Config(
-            cache_dir=pathlib.Path(merged_config["cache-dir"]),
-            include=merged_config["include"],
-            exclude=merged_config["exclude"],
-            respect_gitignore=merged_config["respect-gitignore"],
-            lint=Lint(
-                target_postgres_version=config_lint["target-postgres-version"],
-                additional_non_volatile_functions=frozenset(
-                    config_lint["additional-non-volatile-functions"],
-                ),
-                select=config_lint["select"],
-                ignore=config_lint["ignore"],
-                include=config_lint["include"] + merged_config["include"],
-                exclude=config_lint["exclude"] + merged_config["exclude"],
-                ignore_noqa=config_lint["ignore-noqa"],
-                allowed_extensions=config_lint["allowed-extensions"],
-                allowed_languages=config_lint["allowed-languages"],
-                fix=config_lint["fix"],
-                fixable=config_lint["fixable"],
-                unfixable=config_lint["unfixable"],
-                timestamp_column_suffix=config_lint["timestamp-column-suffix"],
-                date_column_suffix=config_lint["date-column-suffix"],
-                regex_partition=config_lint["regex-partition"],
-                regex_index=config_lint["regex-index"],
-                regex_constraint_primary_key=config_lint["regex-constraint-primary-key"],
-                regex_constraint_unique_key=config_lint["regex-constraint-unique-key"],
-                regex_constraint_foreign_key=config_lint["regex-constraint-foreign-key"],
-                regex_constraint_check=config_lint["regex-constraint-check"],
-                regex_constraint_exclusion=config_lint["regex-constraint-exclusion"],
-                regex_sequence=config_lint["regex-sequence"],
-                required_columns=[
-                    Column(
-                        name=column["name"],
-                        data_type=column["data-type"],
-                    )
-                    for column in config_lint["required-columns"]
-                ],
-                disallowed_data_types=[
-                    DisallowedDataType(
-                        name=data_type["name"],
-                        reason=data_type["reason"],
-                        use_instead=data_type["use-instead"],
-                    )
-                    for data_type in config_lint["disallowed-data-types"]
-                ],
-                disallowed_schemas=[
-                    DisallowedSchema(
-                        name=schema["name"],
-                        reason=schema["reason"],
-                        use_instead=schema["use-instead"],
-                    )
-                    for schema in config_lint["disallowed-schemas"]
-                ],
-            ),
-            format=Format(
-                include=config_format["include"] + merged_config["include"],
-                exclude=config_format["exclude"] + merged_config["exclude"],
-                comma_at_beginning=config_format["comma-at-beginning"],
-                compact_parenthesized_lists_margin=config_format[
-                    "compact-parenthesized-lists-margin"
-                ],
-                uppercase_keywords=config_format["uppercase-keywords"],
-                type_casting_style=_parse_type_casting_style(
-                    config_format["type-casting-style"],
-                ),
-                rewrite_function_calls_as_equivalent_syntax=config_format[
-                    "rewrite-function-calls-as-equivalent-syntax"
-                ],
-                new_line_before_semicolon=config_format["new-line-before-semicolon"],
-                lines_between_statements=config_format["lines-between-statements"],
-                remove_pg_catalog_from_functions=config_format[
-                    "remove-pg-catalog-from-functions"
-                ],
-                remove_default_index_access_method=config_format[
-                    "remove-default-index-access-method"
-                ],
-                diff=config_format["diff"],
-                check=config_format["check"],
-                no_cache=config_format["no-cache"],
-            ),
-        )
-    except KeyError as error:
-        msg = "Missing config key: "
-        raise errors.MissingConfigError(msg + error.args[0]) from error
+    config.lint.include += config.include
+    config.lint.exclude += config.exclude
+    config.format.include += config.include
+    config.format.exclude += config.exclude
+
+    return config

--- a/src/pgrubic/core/config.py
+++ b/src/pgrubic/core/config.py
@@ -30,6 +30,13 @@ _CONFIG_MERGER: typing.Final[merger.Merger] = merger.Merger(
 )
 
 
+_LIST_APPEND_UNIQUE_MERGER: typing.Final[merger.Merger] = merger.Merger(
+    type_strategies=[(list, ["append_unique"])],
+    fallback_strategies=["override"],
+    type_conflict_strategies=["override"],
+)
+
+
 def _parse_type_casting_style(value: object) -> enums.TypeCastingStyle:
     """Parse the configured type-casting style."""
     valid_values = tuple(style.value for style in enums.TypeCastingStyle)
@@ -1174,9 +1181,21 @@ def parse_config(overrides: dict[str, typing.Any] | None = None) -> Config:
     except ValidationError as error:
         _raise_config_validation_error(error)
 
-    config.lint.include += config.include
-    config.lint.exclude += config.exclude
-    config.format.include += config.include
-    config.format.exclude += config.exclude
+    config.lint.include = _LIST_APPEND_UNIQUE_MERGER.merge(
+        config.lint.include,
+        config.include,
+    )
+    config.lint.exclude = _LIST_APPEND_UNIQUE_MERGER.merge(
+        config.lint.exclude,
+        config.exclude,
+    )
+    config.format.include = _LIST_APPEND_UNIQUE_MERGER.merge(
+        config.format.include,
+        config.include,
+    )
+    config.format.exclude = _LIST_APPEND_UNIQUE_MERGER.merge(
+        config.format.exclude,
+        config.exclude,
+    )
 
     return config

--- a/src/pgrubic/rules/general/__init__.py
+++ b/src/pgrubic/rules/general/__init__.py
@@ -16,7 +16,7 @@ def get_columns_from_table_creation(
         given_columns = [
             config.Column(
                 name=column.colname,
-                data_type=column.typeName.names[-1],
+                data_type=column.typeName.names[-1].sval,
             )
             for column in node.tableElts
             if isinstance(column, ast.ColumnDef)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,9 @@
 """Conftest."""
 
-import copy
 import enum
 import typing
 import pathlib
 import contextlib
-import dataclasses
 
 import yaml
 import pytest
@@ -137,8 +135,8 @@ def _update_config(*, config: typing.Any, overrides: dict[str, typing.Any]) -> N
 
 def _restore_config(*, config: typing.Any, previous_config: typing.Any) -> None:
     """Restore a config snapshot while preserving the root object."""
-    for field in dataclasses.fields(config):
-        setattr(config, field.name, getattr(previous_config, field.name))
+    for field_name in type(config).model_fields:
+        setattr(config, field_name, getattr(previous_config, field_name))
 
 
 @contextlib.contextmanager
@@ -148,7 +146,7 @@ def update_config(
     overrides: dict[str, typing.Any],
 ) -> typing.Iterator[None]:
     """Temporarily update a config object with overrides."""
-    previous_config = copy.deepcopy(config)
+    previous_config = config.model_copy(deep=True)
     try:
         _update_config(config=config, overrides=overrides)
         yield

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -338,7 +338,9 @@ def test_cli_lint_missing_config_error(tmp_path: pathlib.Path) -> None:
     with patch("os.getcwd", return_value=str(directory)):
         result = runner.invoke(cli, ["lint", str(file_fail)])
 
-        assert result.output == f"""Missing config key: data-type{noqa.NEW_LINE}"""
+        assert result.output == (
+            f"Missing config key: lint.required-columns.0.data-type{noqa.NEW_LINE}"
+        )
         assert result.exit_code == 1
 
 
@@ -365,7 +367,7 @@ def test_cli_invalid_type_casting_style_error(
 
     assert result.output == (
         'Invalid config value for key "format.type-casting-style": "invalid". '
-        'Expected one of: "native", "standard", "literal"'
+        'Expected one of: "native", "standard", "literal".'
         f"{noqa.NEW_LINE}"
     )
     assert result.exit_code == 1
@@ -703,7 +705,9 @@ def test_cli_format_missing_config_error(tmp_path: pathlib.Path) -> None:
     with patch("os.getcwd", return_value=str(directory)):
         result = runner.invoke(cli, ["format", str(file_fail)])
 
-        assert result.output == f"Missing config key: data-type{noqa.NEW_LINE}"
+        assert result.output == (
+            f"Missing config key: lint.required-columns.0.data-type{noqa.NEW_LINE}"
+        )
 
         assert result.exit_code == 1
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -320,6 +320,22 @@ def test_parsed_config_can_be_used_as_overrides() -> None:
     assert reparsed_config == parsed_config
 
 
+def test_parsed_config_reused_as_overrides_does_not_duplicate_include() -> None:
+    """Reparsing a model_dump() must not duplicate lint/format include-exclude."""
+    parsed_config = config.parse_config(
+        overrides={"include": ["V*.sql"], "exclude": ["test*.sql"]},
+    )
+
+    reparsed_config = config.parse_config(
+        overrides=parsed_config.model_dump(by_alias=True),
+    )
+
+    assert reparsed_config.lint.include == ["V*.sql"]
+    assert reparsed_config.lint.exclude == ["test*.sql"]
+    assert reparsed_config.format.include == ["V*.sql"]
+    assert reparsed_config.format.exclude == ["test*.sql"]
+
+
 def test_user_config_list_replaces_default(tmp_path: pathlib.Path) -> None:
     """Test user-configured lists replace default lists."""
     default_config = dict(toml.load(config.DEFAULT_CONFIG))

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -106,7 +106,9 @@ def test_missing_config_error(tmp_path: pathlib.Path) -> None:
         with pytest.raises(errors.MissingConfigError) as excinfo:
             config.parse_config()
 
-        assert excinfo.value.args[0] == "Missing config key: data-type"
+        assert excinfo.value.args[0] == (
+            "Missing config key: lint.required-columns.0.data-type"
+        )
 
 
 def test_invalid_type_casting_style_error(tmp_path: pathlib.Path) -> None:
@@ -130,7 +132,7 @@ def test_invalid_type_casting_style_error(tmp_path: pathlib.Path) -> None:
         assert (
             excinfo.value.args[0]
             == 'Invalid config value for key "format.type-casting-style": '
-            '"invalid". Expected one of: "native", "standard", "literal"'
+            '"invalid". Expected one of: "native", "standard", "literal".'
         )
 
 
@@ -155,7 +157,7 @@ def test_invalid_type_casting_style_error_suggests_close_match(
     assert (
         excinfo.value.args[0]
         == 'Invalid config value for key "format.type-casting-style": "stand". '
-        'Did you mean "standard"? Expected one of: "native", "standard", "literal"'
+        'Did you mean "standard"? Expected one of: "native", "standard", "literal".'
     )
 
 
@@ -178,7 +180,7 @@ def test_invalid_non_string_type_casting_style_error(tmp_path: pathlib.Path) -> 
     assert (
         excinfo.value.args[0]
         == 'Invalid config value for key "format.type-casting-style": "1". '
-        'Expected one of: "native", "standard", "literal"'
+        'Expected one of: "native", "standard", "literal".'
     )
 
 
@@ -192,6 +194,59 @@ def test_invalid_config_section(section: str) -> None:
         f'Invalid config value for key "{section}": "1". '
         "Expected a configuration section."
     )
+
+
+@pytest.mark.parametrize(
+    ("config_content", "expected_error"),
+    [
+        (
+            '[lint]\nfix = "yes"\n',
+            (
+                'Invalid config value for key "lint.fix": "yes". '
+                "Input should be a valid boolean."
+            ),
+        ),
+        (
+            '[format]\nlines-between-statements = "2"\n',
+            (
+                'Invalid config value for key "format.lines-between-statements": "2". '
+                "Input should be a valid integer."
+            ),
+        ),
+        (
+            "[lint]\nignore = [1]\n",
+            (
+                'Invalid config value for key "lint.ignore.0": "1". '
+                "Input should be a valid string."
+            ),
+        ),
+        (
+            "[format]\nunknown-config = true\n",
+            (
+                'Invalid config value for key "format.unknown-config": "True". '
+                "Extra inputs are not permitted."
+            ),
+        ),
+    ],
+)
+def test_invalid_user_config_value(
+    tmp_path: pathlib.Path,
+    config_content: str,
+    expected_error: str,
+) -> None:
+    """Validate every value loaded from the user configuration."""
+    (tmp_path / config.CONFIG_FILE).write_text(config_content)
+
+    with (
+        patch.dict(
+            "os.environ",
+            {config.CONFIG_PATH_ENVIRONMENT_VARIABLE: str(tmp_path)},
+        ),
+        pytest.raises(errors.InvalidConfigValueError) as excinfo,
+    ):
+        config.parse_config()
+
+    assert excinfo.value.args[0] == expected_error
 
 
 def test_config_file_from_environment_variable_not_found_error() -> None:
@@ -252,6 +307,17 @@ def test_config_user_overrides(tmp_path: pathlib.Path) -> None:
     ):
         parsed_config = config.parse_config(overrides={"lint": {"fix": True}})
         assert parsed_config.lint.fix is True
+
+
+def test_parsed_config_can_be_used_as_overrides() -> None:
+    """Accept already validated configuration values as overrides."""
+    parsed_config = config.parse_config()
+
+    reparsed_config = config.parse_config(
+        overrides=parsed_config.model_dump(by_alias=True),
+    )
+
+    assert reparsed_config == parsed_config
 
 
 def test_user_config_list_replaces_default(tmp_path: pathlib.Path) -> None:


### PR DESCRIPTION
## Background and Motivation
<!-- Why is this change needed? What problem does it solve? -->
This PR migrates `pgrubic`’s configuration parsing/validation to Pydantic models so that user config values (including nested keys and list elements) are strictly validated and error messages can point to precise config paths.

## Summary of Changes
<!-- High-level overview of what was changed. -->
- Replaced dataclass-based config parsing with Pydantic `BaseModel` schemas and centralized validation error translation.
- Updated tests/CLI expectations for more specific config key paths and consistent punctuation in validation errors.
- Adjusted AST type extraction for created-table column data types to provide a string value compatible with strict config validation.
## Type of change
<!-- Select the type of change. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Housekeeping (change that does not affect functionality)

## SQL Examples (if applicable)
<!-- Provide sample SQL to show before/after behavior of the linter/formatter. -->

```sql
-- Before
...

-- After
...
```

## Checklist
<!-- Checklist before requesting a review -->
- [x] I have read and followed the [contributing guidelines](https://github.com/bolajiwahab/pgrubic/blob/main/docs/docs/contributing.md)
- [x] I have checked that there are no other open [Pull Requests](https://github.com/bolajiwahab/pgrubic/pulls) for the same update/change
- [ ] I have performed a self-review of my code
- [x] I have added/updated tests (positive + negative cases)
- [ ] I have updated documentation (if applicable)

## Closes / Fixes
<!-- Link issues using keywords: Closes #123, Fixes #456 -->

## Additional information
<!-- Provide any additional information that might be helpful to the reviewer in reviewing this pull request -->
