### PR TITLE
refactor: narrow typing any annotations

### DIFF
--- a/src/pgrubic/core/config.py
+++ b/src/pgrubic/core/config.py
@@ -1020,23 +1020,23 @@ respect-gitignore = false
         return value
 
 
-def _load_default_config() -> dict[str, typing.Any]:
+def _load_default_config() -> dict[str, object]:
     """Load default config.
 
     Returns:
     -------
-    dict[str, typing.Any]
+    dict[str, object]
         The default config.
     """
     return dict(toml.load(DEFAULT_CONFIG))
 
 
-def _load_user_config() -> dict[str, typing.Any]:
+def _load_user_config() -> dict[str, object]:
     """Load config from absolute path config file.
 
     Returns:
     -------
-    dict[str, typing.Any]
+    dict[str, object]
         The config from the absolute path config file.
     """
     config_file_absolute_path = _get_config_file_absolute_path()
@@ -1053,17 +1053,17 @@ def _load_user_config() -> dict[str, typing.Any]:
     return {}  # pragma: no cover
 
 
-def _merge_config(*, overrides: dict[str, typing.Any]) -> dict[str, typing.Any]:
+def _merge_config(*, overrides: dict[str, object]) -> dict[str, object]:
     """Merge default and user config, with overrides.
 
     Parameters:
     ----------
-    overrides: dict[str, typing.Any]
+    overrides: dict[str, object]
         Overrides applied on top of the user config.
 
     Returns:
     -------
-    dict[str, typing.Any]
+    dict[str, object]
         The merged config.
     """
     merged_config = _CONFIG_MERGER.merge(
@@ -1151,12 +1151,12 @@ def _raise_config_validation_error(error: ValidationError) -> typing.NoReturn:
     raise errors.InvalidConfigValueError(msg) from error
 
 
-def parse_config(overrides: dict[str, typing.Any] | None = None) -> Config:
+def parse_config(overrides: dict[str, object] | None = None) -> Config:
     """Parse config.
 
     Parameters:
     ----------
-    overrides: dict[str, typing.Any] | None, optional
+    overrides: dict[str, object] | None, optional
         Overrides applied on top of the user config.
 
     Returns:

--- a/src/pgrubic/core/linter.py
+++ b/src/pgrubic/core/linter.py
@@ -84,9 +84,9 @@ class CheckerMeta(type):
     def __new__(
         cls: type[CheckerMeta],
         name: str,
-        bases: tuple[typing.Any],
-        dct: dict[str, typing.Any],
-    ) -> typing.Any:
+        bases: tuple[type, ...],
+        dct: dict[str, object],
+    ) -> type:
         """Add method decorations."""
         for attr_name, attr_value in dct.items():
             if callable(attr_value) and attr_name.startswith("_fix"):
@@ -99,8 +99,8 @@ class CheckerMeta(type):
 
     @staticmethod
     def _set_locations(
-        func: abc.Callable[..., typing.Any],
-    ) -> abc.Callable[..., typing.Any]:
+        func: abc.Callable[..., object],
+    ) -> abc.Callable[..., object]:
         """Helper method to set locations for node."""
 
         @functools.wraps(func)
@@ -108,7 +108,7 @@ class CheckerMeta(type):
             checker: BaseChecker,
             ancestors: visitors.Ancestor,
             node: ast.Node,
-        ) -> typing.Any:
+        ) -> object:
             """Set locations for node."""
             # some nodes have location attribute which is different from node location
             # for example ast.CreateTablespaceStmt while some nodes do not carry
@@ -158,16 +158,16 @@ class CheckerMeta(type):
 
     @staticmethod
     def _apply_fix(
-        func: abc.Callable[..., typing.Any],
-    ) -> abc.Callable[..., typing.Any]:
+        func: abc.Callable[..., object],
+    ) -> abc.Callable[..., object]:
         """Helper method to apply fix only if it is applicable."""
 
         @functools.wraps(func)
         def wrapper(
             checker: BaseChecker,
-            *args: typing.Any,
-            **kwargs: typing.Any,
-        ) -> typing.Any:
+            *args: object,
+            **kwargs: object,
+        ) -> object:
             """Apply fix only if it is applicable."""
             if not checker.config.lint.fix:
                 return None
@@ -229,7 +229,7 @@ class BaseChecker(visitors.Visitor, metaclass=CheckerMeta):
         self.violations: set[Violation] = set()
         self.config = config
 
-    def __init_subclass__(cls, **kwargs: typing.Any) -> None:
+    def __init_subclass__(cls, **kwargs: object) -> None:
         """Set code, name and category attributes for subclasses."""
         cls.code = cls.__module__.split(".")[-1]
         cls.name = kebabcase(cls.__name__)

--- a/src/pgrubic/core/visitors.py
+++ b/src/pgrubic/core/visitors.py
@@ -66,13 +66,13 @@ class InlineSQLVisitor(visitors.Visitor):
 
     def _extract_sql_statements_from_plpgsql(
         self,
-        node: typing.Any,
+        node: object,
     ) -> list[str]:
         """Extract SQL statements from PLpgSQL tokens using iterative breadth-first walk.
 
         Parameters:
         ----------
-        node: dict[str, typing.Any]
+        node: object
             PLpgSQL tokens.
 
         Returns:


### PR DESCRIPTION
## Background and Motivation
<!-- Why is this change needed? What problem does it solve? -->
This PR refactors type annotations to reduce use of `typing.Any` by replacing it with narrower types (primarily `object`) across core linting, visitor, and config-loading.

## Summary of Changes
<!-- High-level overview of what was changed. -->
- Updated rule and core APIs to replace `typing.Any` annotations with `object` (and more specific tuple/dict forms).
- Tightened metaclass and decorator wrapper type signatures in `core/linter.py`.
- Narrowed config loader/merge/parse function annotations to `dict[str, object]`.
## Type of change
<!-- Select the type of change. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Housekeeping (change that does not affect functionality)

## SQL Examples (if applicable)
<!-- Provide sample SQL to show before/after behavior of the linter/formatter. -->

```sql
-- Before
...

-- After
...
```

## Checklist
<!-- Checklist before requesting a review -->
- [x] I have read and followed the [contributing guidelines](https://github.com/bolajiwahab/pgrubic/blob/main/docs/docs/contributing.md)
- [x] I have checked that there are no other open [Pull Requests](https://github.com/bolajiwahab/pgrubic/pulls) for the same update/change
- [x] I have performed a self-review of my code
- [ ] I have added/updated tests (positive + negative cases)
- [ ] I have updated documentation (if applicable)

## Closes / Fixes
<!-- Link issues using keywords: Closes #123, Fixes #456 -->

## Additional information
<!-- Provide any additional information that might be helpful to the reviewer in reviewing this pull request -->
