### PR TITLE
fix(rule): crash on fix in US020

### DIFF
--- a/src/pgrubic/rules/unsafe/US020.py
+++ b/src/pgrubic/rules/unsafe/US020.py
@@ -1,7 +1,5 @@
 """Non concurrent reindex."""
 
-import typing
-
 from pglast import ast, enums, visitors
 
 from pgrubic.core import linter
@@ -32,13 +30,11 @@ class NonConcurrentReindex(linter.BaseChecker):
         node: ast.ReindexStmt,
     ) -> None:
         """Visit ReindexStmt."""
-        params: list[typing.Any] = (
-            [param.defname for param in node.params] if node.params else []
-        )
+        param_names = [param.defname for param in node.params] if node.params else []
 
         if (
             node.kind != enums.ReindexObjectType.REINDEX_OBJECT_SYSTEM
-            and "concurrently" not in params
+            and "concurrently" not in param_names
         ):
             self.violations.add(
                 linter.Violation(
@@ -56,10 +52,11 @@ class NonConcurrentReindex(linter.BaseChecker):
                 ),
             )
 
-            self._fix(node, params)
+            self._fix(node)
 
-    def _fix(self, node: ast.ReindexStmt, params: list[typing.Any]) -> None:
+    def _fix(self, node: ast.ReindexStmt) -> None:
         """Fix violation."""
+        params = list(node.params) if node.params else []
         params.append(ast.DefElem(defname="concurrently"))
 
         node.params = params

--- a/tests/fixtures/rules/unsafe/US020.yml
+++ b/tests/fixtures/rules/unsafe/US020.yml
@@ -7,6 +7,13 @@ test_fail_non_concurrent_index_reindex_index:
   sql_fix: |
     REINDEX (CONCURRENTLY) INDEX idx;
 
+test_fail_non_concurrent_index_reindex_with_existing_param:
+  sql_fail: |
+    REINDEX (VERBOSE) INDEX idx;
+  sql_fix: |
+    REINDEX (VERBOSE
+           , CONCURRENTLY) INDEX idx;
+
 test_fail_non_concurrent_index_reindex_table:
   sql_fail: |
     REINDEX TABLE tbl;


### PR DESCRIPTION
## Background and Motivation
<!-- Why is this change needed? What problem does it solve? -->
This PR addresses an auto-fix crash in rule **US020 (Non concurrent reindex)** when fixing `REINDEX` statements that already include other parameters (e.g., `VERBOSE`), by ensuring the fixer operates on AST `DefElem` nodes rather than a list of parameter-name strings.
## Summary of Changes
<!-- High-level overview of what was changed. -->
- Update US020’s fix logic to append `CONCURRENTLY` to the existing AST `params` list (instead of mixing strings with AST nodes).
- Add a regression fixture covering `REINDEX (VERBOSE) ...` to validate fix behavior with existing parameters.
## Type of change
<!-- Select the type of change. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Housekeeping (change that does not affect functionality)

## SQL Examples (if applicable)
<!-- Provide sample SQL to show before/after behavior of the linter/formatter. -->

```sql
-- Before
...

-- After
...
```

## Checklist
<!-- Checklist before requesting a review -->
- [x] I have read and followed the [contributing guidelines](https://github.com/bolajiwahab/pgrubic/blob/main/docs/docs/contributing.md)
- [x] I have checked that there are no other open [Pull Requests](https://github.com/bolajiwahab/pgrubic/pulls) for the same update/change
- [x] I have performed a self-review of my code
- [x] I have added/updated tests (positive + negative cases)
- [ ] I have updated documentation (if applicable)

## Closes / Fixes
<!-- Link issues using keywords: Closes #123, Fixes #456 -->

## Additional information
<!-- Provide any additional information that might be helpful to the reviewer in reviewing this pull request -->
