### PR TITLE
fix(rule): prevent duplicate-index state from leaking across lint sessions

### DIFF
--- a/src/pgrubic/rules/general/GN025.py
+++ b/src/pgrubic/rules/general/GN025.py
@@ -1,10 +1,8 @@
 """Checker for duplicate indexes."""
 
-import typing
-
 from pglast import ast, visitors
 
-from pgrubic.core import linter
+from pgrubic.core import config, linter
 
 
 class DuplicateIndex(linter.BaseChecker):
@@ -28,7 +26,10 @@ class DuplicateIndex(linter.BaseChecker):
     Remove the duplicate.
     """
 
-    seen_indexes: typing.ClassVar[list[typing.Any]] = []
+    def __init__(self, *, config: config.Config) -> None:
+        """Initialize the DuplicateIndex checker."""
+        super().__init__(config=config)
+        self.seen_indexes: list[tuple[object, object, object, object]] = []
 
     def visit_IndexStmt(
         self,

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -88,3 +88,27 @@ def test_rules(
             ), (
                 f"""Test failed: Violations found for rule: `{rule}` in `{test_id}` which should pass"""  # noqa: E501
             )
+
+
+def test_duplicate_index_state_not_shared_across_linter_instances() -> None:
+    """Regression test for GN025's seen_indexes leaking across checker instances.
+
+    Deliberately builds its own Linter instead of using the module-scoped `linter`
+    fixture: that fixture creates checkers once and reuses them for every
+    parametrized case in this module, so it can't distinguish state that's scoped
+    to one checker instance from state that's shared at the class level (which is
+    exactly the bug being guarded against here).
+    """
+    sql = "CREATE INDEX idx ON tbl (col);"
+
+    for _ in range(2):
+        config = core.parse_config()
+        linter = core.Linter(config=config, formatters=core.load_formatters)
+        for rule in core.load_rules(config=config, include_deprecated=True):
+            linter.checkers.add(rule(config=config))
+
+        linting_result = linter.run(source_file="test.sql", source_code=sql)
+
+        assert not any(
+            violation.rule_code == "GN025" for violation in linting_result.violations
+        ), "Test failed: index flagged as duplicate across independent Linter instances"


### PR DESCRIPTION
## Background and Motivation
<!-- Why is this change needed? What problem does it solve? -->
This PR addresses a state-leak bug in the GN025 “DuplicateIndex” rule by moving index-tracking state off the class and adding a regression test to prevent future regressions.

## Summary of Changes
<!-- High-level overview of what was changed. -->
- Update GN025 to store `seen_indexes` on the checker instance instead of as a class-level variable.
- Add a regression test intended to ensure duplicate-index tracking doesn’t leak beyond its intended scope.
## Type of change
<!-- Select the type of change. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Housekeeping (change that does not affect functionality)

## SQL Examples (if applicable)
<!-- Provide sample SQL to show before/after behavior of the linter/formatter. -->

```sql
-- Before
...

-- After
...
```

## Checklist
<!-- Checklist before requesting a review -->
- [x] I have read and followed the [contributing guidelines](https://github.com/bolajiwahab/pgrubic/blob/main/docs/docs/contributing.md)
- [x] I have checked that there are no other open [Pull Requests](https://github.com/bolajiwahab/pgrubic/pulls) for the same update/change
- [x] I have performed a self-review of my code
- [x] I have added/updated tests (positive + negative cases)
- [ ] I have updated documentation (if applicable)

## Closes / Fixes
<!-- Link issues using keywords: Closes #123, Fixes #456 -->

## Additional information
<!-- Provide any additional information that might be helpful to the reviewer in reviewing this pull request -->
