### PR TITLE
feat(cli): allow lint violations to exit with 0 via -e, --exit-zero

### DIFF
--- a/docs/docs/cli.md
+++ b/docs/docs/cli.md
@@ -42,6 +42,8 @@ Options:
                                  SQL file, causing the entire file to be ignored
                                  by the linter.
   --generate-lint-report         Generate a lint report.
+  -e, --exit-zero                Exit with status code "0", even upon
+                                 detecting lint violations.
   --config <CONFIG_OPTION>       A TOML `<KEY> = <VALUE>` pair overriding a
                                  configuration option. May be repeated. Command-
                                  line overrides always take precedence over

--- a/docs/docs/cli.md
+++ b/docs/docs/cli.md
@@ -42,8 +42,8 @@ Options:
                                  SQL file, causing the entire file to be ignored
                                  by the linter.
   --generate-lint-report         Generate a lint report.
-  -e, --exit-zero                Exit with status code "0", even upon
-                                 detecting lint violations.
+  -e, --exit-zero                Exit with status code "0", even when lint
+                                 violations are present.
   --config <CONFIG_OPTION>       A TOML `<KEY> = <VALUE>` pair overriding a
                                  configuration option. May be repeated. Command-
                                  line overrides always take precedence over

--- a/src/pgrubic/__main__.py
+++ b/src/pgrubic/__main__.py
@@ -91,6 +91,13 @@ def cli() -> None:
     default=False,
     help="Generate a lint report.",
 )
+@click.option(
+    "-e",
+    "--exit-zero",
+    is_flag=True,
+    default=False,
+    help='Exit with status code "0", even upon detecting lint violations.',
+)
 @common_options
 @click.argument("sources", nargs=-1, type=click.Path(exists=True, path_type=pathlib.Path))  # type: ignore [type-var]
 def lint(  # noqa: C901, PLR0912, PLR0913, PLR0915
@@ -100,6 +107,7 @@ def lint(  # noqa: C901, PLR0912, PLR0913, PLR0915
     ignore_noqa: bool,
     add_file_level_general_noqa: bool,
     generate_lint_report: bool,
+    exit_zero: bool,
     config_overrides: tuple[str, ...],
     workers: int,
     verbose: bool,
@@ -118,6 +126,8 @@ def lint(  # noqa: C901, PLR0912, PLR0913, PLR0915
         Whether to add file-level noqa directives.
     generate_lint_report: bool
         Whether to generate a lint report.
+    exit_zero: bool
+        Whether to exit with status code 0, even upon detecting lint violations.
     config_overrides: tuple[str, ...]
         TOML key-value pairs overriding configuration options.
     workers: int
@@ -251,7 +261,9 @@ def lint(  # noqa: C901, PLR0912, PLR0913, PLR0915
                 f"{total_errors} error(s) found{noqa.NEW_LINE}",
             )
 
-            if (total_violations - fix_enabled_violations) > 0 or total_errors > 0:
+            if total_errors > 0 or (
+                (total_violations - fix_enabled_violations) > 0 and not exit_zero
+            ):
                 sys.exit(1)
 
         else:
@@ -266,7 +278,8 @@ def lint(  # noqa: C901, PLR0912, PLR0913, PLR0915
                     f"Use with '--fix' to auto fix the violations{noqa.NEW_LINE}",
                 )
 
-            sys.exit(1)
+            if total_errors > 0 or not exit_zero:
+                sys.exit(1)
     else:
         sys.stdout.write(f"All checks passed!{noqa.NEW_LINE}")
 

--- a/src/pgrubic/__main__.py
+++ b/src/pgrubic/__main__.py
@@ -96,7 +96,7 @@ def cli() -> None:
     "--exit-zero",
     is_flag=True,
     default=False,
-    help='Exit with status code "0", even upon detecting lint violations.',
+    help='Exit with status code "0", even when lint violations are present.',
 )
 @common_options
 @click.argument("sources", nargs=-1, type=click.Path(exists=True, path_type=pathlib.Path))  # type: ignore [type-var]
@@ -127,7 +127,7 @@ def lint(  # noqa: C901, PLR0912, PLR0913, PLR0915
     generate_lint_report: bool
         Whether to generate a lint report.
     exit_zero: bool
-        Whether to exit with status code 0, even upon detecting lint violations.
+        Whether to exit with status code 0, even when lint violations are present.
     config_overrides: tuple[str, ...]
         TOML key-value pairs overriding configuration options.
     workers: int

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -85,6 +85,41 @@ def test_cli_lint_file(tmp_path: pathlib.Path) -> None:
     assert result.exit_code == 1
 
 
+@pytest.mark.parametrize("flag", ["-e", "--exit-zero"])
+def test_cli_lint_exit_zero(tmp_path: pathlib.Path, flag: str) -> None:
+    """Test cli lint --exit-zero exits 0 despite violations."""
+    runner = testing.CliRunner()
+
+    sql_fail: str = "SELECT a = NULL;"
+
+    directory = tmp_path / "sub"
+    directory.mkdir()
+
+    file_fail = directory / TEST_FILE
+    file_fail.write_text(sql_fail)
+
+    result = runner.invoke(cli, ["lint", str(file_fail), flag])
+
+    assert result.exit_code == 0
+
+
+def test_cli_lint_exit_zero_does_not_suppress_errors(tmp_path: pathlib.Path) -> None:
+    """Test cli lint --exit-zero still exits non-zero on parse errors."""
+    runner = testing.CliRunner()
+
+    sql_invalid: str = "SELECT * FROM;"
+
+    directory = tmp_path / "sub"
+    directory.mkdir()
+
+    file_invalid = directory / TEST_FILE
+    file_invalid.write_text(sql_invalid)
+
+    result = runner.invoke(cli, ["lint", str(file_invalid), "--exit-zero"])
+
+    assert result.exit_code == 1
+
+
 def test_cli_lint_directory(tmp_path: pathlib.Path) -> None:
     """Test cli lint directory."""
     runner = testing.CliRunner()


### PR DESCRIPTION
## Background and Motivation
<!-- Why is this change needed? What problem does it solve? -->
Adds a new `lint` CLI option to treat lint *violations* as non-fatal (exit status 0), which is useful for CI/reporting workflows where violations should be reported but not fail the job.

## Summary of Changes
<!-- High-level overview of what was changed. -->
- Introduces `-e, --exit-zero` to `pgrubic lint` to exit 0 when only lint violations are present.
- Preserves non-zero exit behavior for actual errors (e.g., parse errors), even when `--exit-zero` is set.
- Adds CLI documentation and test coverage for both the “violations-only” and “errors still fail” behaviors.
## Type of change
<!-- Select the type of change. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Housekeeping (change that does not affect functionality)

## SQL Examples (if applicable)
<!-- Provide sample SQL to show before/after behavior of the linter/formatter. -->

```sql
-- Before
...

-- After
...
```

## Checklist
<!-- Checklist before requesting a review -->
- [x] I have read and followed the [contributing guidelines](https://github.com/bolajiwahab/pgrubic/blob/main/docs/docs/contributing.md)
- [x] I have checked that there are no other open [Pull Requests](https://github.com/bolajiwahab/pgrubic/pulls) for the same update/change
- [x] I have performed a self-review of my code
- [x] I have added/updated tests (positive + negative cases)
- [x] I have updated documentation (if applicable)

## Closes / Fixes
<!-- Link issues using keywords: Closes #123, Fixes #456 -->

## Additional information
<!-- Provide any additional information that might be helpful to the reviewer in reviewing this pull request -->
