### PR TITLE
fix(cli): avoid rewriting and misreporting already-formatted files

### DIFF
--- a/src/pgrubic/__main__.py
+++ b/src/pgrubic/__main__.py
@@ -422,17 +422,20 @@ def format_sources(  # noqa: C901, PLR0912, PLR0913, PLR0915
         formatting_results = [result.get() for result in results]
 
     changes_detected = False
+    files_reformatted = 0
     total_errors = 0
 
     for formatting_result in formatting_results:
-        if (
+        content_changed = (
             formatting_result.formatted_source_code
             != formatting_result.original_source_code
-            and not changes_detected
-        ):
-            changes_detected = True
+        )
 
-        if config.format.diff:
+        if content_changed:
+            changes_detected = True
+            files_reformatted += 1
+
+        if config.format.diff and content_changed:
             diff_unified = difflib.unified_diff(
                 formatting_result.original_source_code.splitlines(keepends=True),
                 formatting_result.formatted_source_code.splitlines(keepends=True),
@@ -442,10 +445,11 @@ def format_sources(  # noqa: C901, PLR0912, PLR0913, PLR0915
 
             diff_output = "".join(diff_unified)
 
-            if diff_output:
-                console.print(Syntax(diff_output, "diff", theme="ansi_dark"))
+            console.print(Syntax(diff_output, "diff", theme="ansi_dark"))
 
-        if not config.format.check and not config.format.diff:
+        # Only touch the file when its content genuinely changed, so a cache
+        # miss on an already-correctly-formatted file never rewrites it.
+        if not config.format.check and not config.format.diff and content_changed:
             pathlib.Path(formatting_result.source_file).write_text(
                 formatting_result.formatted_source_code,
                 encoding="utf-8",
@@ -461,8 +465,8 @@ def format_sources(  # noqa: C901, PLR0912, PLR0913, PLR0915
     if not config.format.check and not config.format.diff:
         cache.write(sources=sources_to_format)
         sys.stdout.write(
-            f"{noqa.NEW_LINE}{len(sources_to_format)} file(s) reformatted, "
-            f"{len(included_sources) - len(sources_to_format)} file(s) left unchanged{noqa.NEW_LINE}",  # noqa: E501
+            f"{noqa.NEW_LINE}{files_reformatted} file(s) reformatted, "
+            f"{len(included_sources) - files_reformatted} file(s) left unchanged{noqa.NEW_LINE}",  # noqa: E501
         )
         if total_errors > 0:
             sys.stdout.write(f"{total_errors} error(s) found{noqa.NEW_LINE}")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -472,7 +472,7 @@ def test_cli_format_files(tmp_path: pathlib.Path) -> None:
     """Test cli format source files."""
     runner = testing.CliRunner()
 
-    source_code: str = f"SELECT a = NULL;{noqa.NEW_LINE}"
+    source_code: str = f"select a = null;{noqa.NEW_LINE}"
 
     directory = tmp_path / "sub"
     directory.mkdir()
@@ -537,7 +537,7 @@ def test_cli_format_directory(tmp_path: pathlib.Path) -> None:
     """Test cli format directory."""
     runner = testing.CliRunner()
 
-    sql_pass: str = f"SELECT a = NULL;{noqa.NEW_LINE}"
+    sql_pass: str = f"select a = null;{noqa.NEW_LINE}"
 
     directory = tmp_path / "sub"
     directory.mkdir()
@@ -667,15 +667,19 @@ def test_cli_format_no_cache(tmp_path: pathlib.Path) -> None:
 
     assert result.exit_code == 0
 
-    # without cache
+    # without cache read: forces reprocessing, but the file is already correctly
+    # formatted by now, so nothing actually changes on disk.
+    mtime_before_forced_reprocessing = file_fail.stat().st_mtime_ns
+
     result = runner.invoke(cli, ["format", str(file_fail), "--no-cache"])
 
     assert (
         result.output
-        == f"{noqa.NEW_LINE}1 file(s) reformatted, 0 file(s) left unchanged{noqa.NEW_LINE}"  # noqa: E501
+        == f"{noqa.NEW_LINE}0 file(s) reformatted, 1 file(s) left unchanged{noqa.NEW_LINE}"  # noqa: E501
     )
 
     assert result.exit_code == 0
+    assert file_fail.stat().st_mtime_ns == mtime_before_forced_reprocessing
 
 
 def test_cli_format_parse_error(tmp_path: pathlib.Path) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -486,7 +486,16 @@ def test_cli_format_files(tmp_path: pathlib.Path) -> None:
     source_3 = directory / "source_3.sql"
     source_3.write_text(source_code)
 
-    result = runner.invoke(cli, ["format", str(source_1), str(source_2)])
+    result = runner.invoke(
+        cli,
+        [
+            "format",
+            str(source_1),
+            str(source_2),
+            "--config",
+            "format.uppercase-keywords = true",
+        ],
+    )
 
     assert (
         result.output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,6 @@
 """Test cli."""
 
+import os
 import pathlib
 from unittest.mock import patch
 
@@ -677,8 +678,12 @@ def test_cli_format_no_cache(tmp_path: pathlib.Path) -> None:
     assert result.exit_code == 0
 
     # without cache read: forces reprocessing, but the file is already correctly
-    # formatted by now, so nothing actually changes on disk.
-    mtime_before_forced_reprocessing = file_fail.stat().st_mtime_ns
+    # formatted by now, so nothing actually changes on disk. Set the mtime to a
+    # deliberately old, unambiguous value first: comparing two "now"-ish samples
+    # could false-negative on filesystems with coarse mtime resolution, where a
+    # real rewrite could land in the same tick as the pre-run sample.
+    old_mtime_ns = 0
+    os.utime(file_fail, ns=(old_mtime_ns, old_mtime_ns))
 
     result = runner.invoke(cli, ["format", str(file_fail), "--no-cache"])
 
@@ -688,7 +693,7 @@ def test_cli_format_no_cache(tmp_path: pathlib.Path) -> None:
     )
 
     assert result.exit_code == 0
-    assert file_fail.stat().st_mtime_ns == mtime_before_forced_reprocessing
+    assert file_fail.stat().st_mtime_ns == old_mtime_ns
 
 
 def test_cli_format_parse_error(tmp_path: pathlib.Path) -> None:


### PR DESCRIPTION
## Background and Motivation
<!-- Why is this change needed? What problem does it solve? -->
This PR updates the `format` CLI flow to avoid rewriting files whose formatted output is identical to the original content, and to report “reformatted vs unchanged” counts based on actual content changes rather than cache misses.
## Summary of Changes
<!-- High-level overview of what was changed. -->
- Track per-file `content_changed` and only write back to disk when the formatted output differs.
- Compute “reformatted” count from actual changed files (`files_reformatted`) and use it in the CLI summary output.
- Adjust CLI tests for `--no-cache` to expect “unchanged” when a file is already formatted, and add an mtime check.
## Type of change
<!-- Select the type of change. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Housekeeping (change that does not affect functionality)

## SQL Examples (if applicable)
<!-- Provide sample SQL to show before/after behavior of the linter/formatter. -->

```sql
-- Before
...

-- After
...
```

## Checklist
<!-- Checklist before requesting a review -->
- [ ] I have read and followed the [contributing guidelines](https://github.com/bolajiwahab/pgrubic/blob/main/docs/docs/contributing.md)
- [ ] I have checked that there are no other open [Pull Requests](https://github.com/bolajiwahab/pgrubic/pulls) for the same update/change
- [ ] I have performed a self-review of my code
- [ ] I have added/updated tests (positive + negative cases)
- [ ] I have updated documentation (if applicable)

## Closes / Fixes
<!-- Link issues using keywords: Closes #123, Fixes #456 -->

## Additional information
<!-- Provide any additional information that might be helpful to the reviewer in reviewing this pull request -->
