### PR TITLE
docs: fix cache-dir environment variable name in config docs

### DIFF
--- a/docs/docs/settings.md
+++ b/docs/docs/settings.md
@@ -3,7 +3,7 @@
 ### **cache-dir**
 Path to the cache directory.
 
-If default and the environment variable `{PGRUBIC_CACHE_DIR}` is set, the environment
+If default and the environment variable `PGRUBIC_CACHE_DIR` is set, the environment
 variable takes precedence or otherwise the non-default set value is always used.
 
 **Type**: `str`

--- a/docs/docs/settings.md
+++ b/docs/docs/settings.md
@@ -3,12 +3,14 @@
 ### **cache-dir**
 Path to the cache directory.
 
-If default and the environment variable `PGRUBIC_CACHE` is set, the environment
+If default and the environment variable `{PGRUBIC_CACHE_DIR}` is set, the environment
 variable takes precedence or otherwise the non-default set value is always used.
 
 **Type**: `str`
 
 **Default**: `".pgrubic_cache"`
+
+**Environment Variable**: `PGRUBIC_CACHE_DIR`
 
 **Example**:
 <details open>

--- a/src/pgrubic/core/config.py
+++ b/src/pgrubic/core/config.py
@@ -936,12 +936,14 @@ class Config(BaseConfig):
 ### **cache-dir**
 Path to the cache directory.
 
-If default and the environment variable `PGRUBIC_CACHE` is set, the environment
+If default and the environment variable `{PGRUBIC_CACHE_DIR}` is set, the environment
 variable takes precedence or otherwise the non-default set value is always used.
 
 **Type**: `str`
 
 **Default**: `".pgrubic_cache"`
+
+**Environment Variable**: `PGRUBIC_CACHE_DIR`
 
 **Example**:
 <details open>

--- a/src/pgrubic/core/config.py
+++ b/src/pgrubic/core/config.py
@@ -936,7 +936,7 @@ class Config(BaseConfig):
 ### **cache-dir**
 Path to the cache directory.
 
-If default and the environment variable `{PGRUBIC_CACHE_DIR}` is set, the environment
+If default and the environment variable `PGRUBIC_CACHE_DIR` is set, the environment
 variable takes precedence or otherwise the non-default set value is always used.
 
 **Type**: `str`


### PR DESCRIPTION
## Background and Motivation
<!-- Why is this change needed? What problem does it solve? -->
Updates the configuration documentation embedded in `Config` to correct the cache directory environment variable name and clarify how it overrides the default cache directory.

## Summary of Changes
<!-- High-level overview of what was changed. -->
- Corrects the referenced cache-dir environment variable to `PGRUBIC_CACHE_DIR`.
- Adds an explicit “Environment Variable” line for the `cache-dir` option in the config docs.
## Type of change
<!-- Select the type of change. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Housekeeping (change that does not affect functionality)

## SQL Examples (if applicable)
<!-- Provide sample SQL to show before/after behavior of the linter/formatter. -->

```sql
-- Before
...

-- After
...
```

## Checklist
<!-- Checklist before requesting a review -->
- [x] I have read and followed the [contributing guidelines](https://github.com/bolajiwahab/pgrubic/blob/main/docs/docs/contributing.md)
- [x] I have checked that there are no other open [Pull Requests](https://github.com/bolajiwahab/pgrubic/pulls) for the same update/change
- [x] I have performed a self-review of my code
- [ ] I have added/updated tests (positive + negative cases)
- [x] I have updated documentation (if applicable)

## Closes / Fixes
<!-- Link issues using keywords: Closes #123, Fixes #456 -->

## Additional information
<!-- Provide any additional information that might be helpful to the reviewer in reviewing this pull request -->
