### PR TITLE
chore(release): generate github release notes from preceding tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,8 +23,11 @@ jobs:
       new_version: ${{ steps.release.outputs.new_version }}
       suffix: ${{ steps.release.outputs.suffix }}
       tag_name: ${{ steps.release.outputs.tag_name }}
+      previous_tag: ${{ steps.release.outputs.previous_tag }}
     steps:
       - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
 
       - name: Extract tag and Details
         id: release
@@ -33,12 +36,18 @@ jobs:
             TAG_NAME=${GITHUB_REF#refs/tags/}
             NEW_VERSION=$(echo $TAG_NAME | awk -F'-' '{print $1}')
             SUFFIX=$(echo $TAG_NAME | grep -oP '[a-z]+[0-9]+' || echo "")
+            PREVIOUS_TAG=$(git tag --sort=-v:refname | grep -F -x -A1 "$TAG_NAME" | tail -n 1)
+            if [ "$PREVIOUS_TAG" = "$TAG_NAME" ]; then
+              PREVIOUS_TAG=""
+            fi
             echo "new_version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
             echo "suffix=$SUFFIX" >> "$GITHUB_OUTPUT"
             echo "tag_name=$TAG_NAME" >> "$GITHUB_OUTPUT"
+            echo "previous_tag=$PREVIOUS_TAG" >> "$GITHUB_OUTPUT"
             echo "Version is $NEW_VERSION"
             echo "Suffix is $SUFFIX"
             echo "Tag name is $TAG_NAME"
+            echo "Previous tag is $PREVIOUS_TAG"
           else
             echo "No tag found"
             exit 1
@@ -79,6 +88,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v7
@@ -140,8 +151,16 @@ jobs:
         id: create_release
         env:
           GH_TOKEN: ${{ github.token }}
+          TAG_NAME: ${{ needs.details.outputs.tag_name }}
+          PREVIOUS_TAG: ${{ needs.details.outputs.previous_tag }}
         run: |
-          gh release create ${{ needs.details.outputs.tag_name }} dist/* --title ${{ needs.details.outputs.tag_name }} --generate-notes
+          if [ -n "$PREVIOUS_TAG" ]; then
+            echo "Generating notes from $PREVIOUS_TAG to $TAG_NAME"
+            gh release create "$TAG_NAME" dist/* --title "$TAG_NAME" --generate-notes --notes-start-tag "$PREVIOUS_TAG"
+          else
+            echo "No previous tag found, generating notes from the beginning of history"
+            gh release create "$TAG_NAME" dist/* --title "$TAG_NAME" --generate-notes
+          fi
 
   docker_image_release:
     name: Publish multi-platform docker image [arch=amd64,arm64]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,12 @@ jobs:
             TAG_NAME=${GITHUB_REF#refs/tags/}
             NEW_VERSION=$(echo $TAG_NAME | awk -F'-' '{print $1}')
             SUFFIX=$(echo $TAG_NAME | grep -oP '[a-z]+[0-9]+' || echo "")
+            # git's version sort does not know our compact prerelease suffixes
+            # (a1, b1, rc1 with no separator) are prereleases, so by default it
+            # sorts e.g. 2.0.0rc1 above 2.0.0.
+            git config versionsort.suffix "a"
+            git config --add versionsort.suffix "b"
+            git config --add versionsort.suffix "rc"
             PREVIOUS_TAG=$(git tag --sort=-v:refname | grep -F -x -A1 "$TAG_NAME" | tail -n 1)
             if [ "$PREVIOUS_TAG" = "$TAG_NAME" ]; then
               PREVIOUS_TAG=""

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,8 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          fetch-depth: 0
+          fetch-depth: 1
+          fetch-tags: true
 
       - name: Extract tag and Details
         id: release
@@ -95,7 +96,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          fetch-depth: 0
+          fetch-depth: 1
 
       - name: Set up Python
         uses: actions/setup-python@v7
@@ -145,7 +146,7 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v7
         with:
-          fetch-depth: 0
+          fetch-depth: 1
 
       - name: Download artifacts
         uses: actions/download-artifact@v8
@@ -181,7 +182,7 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v7
         with:
-          fetch-depth: 0
+          fetch-depth: 1
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,9 +6,6 @@ on:  # yamllint disable-line rule:truthy
   push:
     tags:
       - "[0-9]+.[0-9]+.[0-9]+"
-      - "[0-9]+.[0-9]+.[0-9]+a[0-9]+"
-      - "[0-9]+.[0-9]+.[0-9]+b[0-9]+"
-      - "[0-9]+.[0-9]+.[0-9]+rc[0-9]+"
 
 env:
   PACKAGE_NAME: "pgrubic"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,9 @@ on:  # yamllint disable-line rule:truthy
   push:
     tags:
       - "[0-9]+.[0-9]+.[0-9]+"
+      - "[0-9]+.[0-9]+.[0-9]+a[0-9]+"
+      - "[0-9]+.[0-9]+.[0-9]+b[0-9]+"
+      - "[0-9]+.[0-9]+.[0-9]+rc[0-9]+"
 
 env:
   PACKAGE_NAME: "pgrubic"


### PR DESCRIPTION
## Background and Motivation
<!-- Why is this change needed? What problem does it solve? -->
Updates the release workflow to generate GitHub release notes from the preceding tag.
## Summary of Changes
<!-- High-level overview of what was changed. -->
- Fetches complete tag history.
- Determines and exports the previous tag.
- Uses `--notes-start-tag` with a first-release fallback.
## Type of change
<!-- Select the type of change. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Housekeeping (change that does not affect functionality)

## SQL Examples (if applicable)
<!-- Provide sample SQL to show before/after behavior of the linter/formatter. -->

```sql
-- Before
...

-- After
...
```

## Checklist
<!-- Checklist before requesting a review -->
- [x] I have read and followed the [contributing guidelines](https://github.com/bolajiwahab/pgrubic/blob/main/docs/docs/contributing.md)
- [x] I have checked that there are no other open [Pull Requests](https://github.com/bolajiwahab/pgrubic/pulls) for the same update/change
- [x] I have performed a self-review of my code
- [ ] I have added/updated tests (positive + negative cases)
- [ ] I have updated documentation (if applicable)

## Closes / Fixes
<!-- Link issues using keywords: Closes #123, Fixes #456 -->

## Additional information
<!-- Provide any additional information that might be helpful to the reviewer in reviewing this pull request -->
