### PR TITLE
docs: add comments on the default configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,12 +124,12 @@ pgrubic format directory/*.sql         # Format SQL files in *directory*
 pgrubic format directory/file.sql      # Format `file.sql` in *directory*
 pgrubic format file.sql                # Format `file.sql`
 pgrubic format directory/*.sql --check # Check if SQL files would have been modified, returning a non-zero exit code
-pgrubic format file.sql --diff         # Report if `file.sql` would have been modified, returning a non-zero exit code as well the difference between `file.sql` and how the formatted file would look like
+pgrubic format file.sql --diff         # Report if `file.sql` would have been modified, returning a non-zero exit code as well as the difference between `file.sql` and how the formatted file would look like
 ```
 
 ## Configuration
 
-pgrubic can be configured via the [`pgrubic.toml`] file in either the current directory, up to the root directory or the path set by the `PGRUBIC_CONFIG_PATH` environment variable. The config values can also be overridden using the `--config <CONFIG_OPTION>` command-line argument.
+pgrubic can be configured via the [`pgrubic.toml`] file in either the current directory, up to the root directory or the path set by the `PGRUBIC_CONFIG_PATH` environment variable. Config values can also be overridden using the `--config` command-line argument, which accepts a TOML `<KEY> = <VALUE>` pair and may be repeated, e.g. `--config "lint.target-postgres-version = 17"`.
 
 The following configuration options are available in the [`pgrubic.toml`] with the following defaults:
 
@@ -194,10 +194,10 @@ disallowed-data-types = []
 # Required columns
 required-columns = []
 
-# Suffix Timestamp columns with `_at`
+# Suffix timestamp columns with `_at`
 timestamp-column-suffix = "_at"
 
-# Suffix Date columns with suffix `_date`
+# Suffix date columns with `_date`
 date-column-suffix = "_date"
 
 # Allow any naming convention for partitions

--- a/README.md
+++ b/README.md
@@ -200,10 +200,10 @@ timestamp-column-suffix = "_at"
 # Suffix Date columns with suffix `_date`
 date-column-suffix = "_date"
 
-# Allow nay naming convention for partitions
+# Allow any naming convention for partitions
 regex-partition = "^.+$"
 
-# Allow all any naming convention for indexes
+# Allow any naming convention for indexes
 regex-index = "^.+$"
 
 # Allow any naming convention for primary key constraints

--- a/README.md
+++ b/README.md
@@ -129,58 +129,144 @@ pgrubic format file.sql --diff         # Report if `file.sql` would have been mo
 
 ## Configuration
 
-pgrubic can be configured via the [`pgrubic.toml`] file in either the current directory, up to the root directory or the path set by the `PGRUBIC_CONFIG_PATH` environment variable.
+pgrubic can be configured via the [`pgrubic.toml`] file in either the current directory, up to the root directory or the path set by the `PGRUBIC_CONFIG_PATH` environment variable. The config values can also be overridden using the `--config <CONFIG_OPTION>` command-line argument.
 
 The following configuration options are available in the [`pgrubic.toml`] with the following defaults:
 
 <!-- BEGIN GENERATED DEFAULT CONFIG -->
 
 ```toml
+# Path to the cache directory
 cache-dir = ".pgrubic_cache"
+
+# Include all files
 include = []
+
+# Exclude no files
 exclude = []
+
+# Respect gitignore
 respect-gitignore = true
+
 [lint]
+# Target version 14 of PostgreSQL
 target-postgres-version = 14
-additional-non-volatile-functions = []
+
+# Enable all rules
 select = []
+
+# Disable no rules
 ignore = []
+
+# Include all files
 include = []
+
+# Exclude no files
 exclude = []
+
+# Ignore suppressing violations that are marked as `noqa`
 ignore-noqa = false
+
+# List of additional non-volatile functions
+additional-non-volatile-functions = []
+
+# Disallowed schemas
 disallowed-schemas = []
+
+# Allowed extensions
 allowed-extensions = []
+
+# Allowed languages
 allowed-languages = []
+
+# Do not fix violations automatically
 fix = false
+
+# Consider all rules as fixable
 fixable = []
+
+# Consider all rules as fixable
 unfixable = []
+
+# Disallowed data types
 disallowed-data-types = []
+
+# Required columns
 required-columns = []
+
+# Suffix Timestamp columns with `_at`
 timestamp-column-suffix = "_at"
+
+# Suffix Date columns with suffix `_date`
 date-column-suffix = "_date"
+
+# Allow nay naming convention for partitions
 regex-partition = "^.+$"
+
+# Allow all any naming convention for indexes
 regex-index = "^.+$"
+
+# Allow any naming convention for primary key constraints
 regex-constraint-primary-key = "^.+$"
+
+# ALlow any naming convention for unique keys
 regex-constraint-unique-key = "^.+$"
+
+# Allow any naming convention for foreign keys
 regex-constraint-foreign-key = "^.+$"
+
+# Allow any naming convention for check constraints
 regex-constraint-check = "^.+$"
+
+# Allow any naming convention for exclusion constraints
 regex-constraint-exclusion = "^.+$"
+
+# Allow any naming convention for sequences
 regex-sequence = "^.+$"
 
 [format]
+# Include all files
 include = []
+
+# Exclude no files
 exclude = []
+
+# Comma at the beginning of an item
 comma-at-beginning = true
+
+# Compact parenthesized lists margin of 90
 compact-parenthesized-lists-margin = 90
+
+# Uppercase keywords
 uppercase-keywords = true
+
+# Type casting style is standard
+# CAST(value AS type)
 type-casting-style = "standard"
+
+# Rewrite some function calls using their equivalent SQL syntax.
+# For example, pg_catalog.timezone('UTC', value) is formatted as "value AT TIME ZONE 'UTC'"
 rewrite-function-calls-as-equivalent-syntax = true
+
+# New line before semicolon false
 new-line-before-semicolon = false
+
+# Remove pg_catalog from functions
 remove-pg-catalog-from-functions = true
+
+# Remove default index access method (btree)
 remove-default-index-access-method = true
+
+# Separate statements by a certain number by of new line, 1
 lines-between-statements = 1
+
+# Check if files would have been modified, returning a non-zero exit code
 check = false
+
+# Report if files would have been modified, returning a non-zero exit code as well the difference between the current file and how the formatted file would look like
 diff = false
+
+# Whether to read the cache.
 no-cache = false
 ```
 

--- a/README.md
+++ b/README.md
@@ -263,10 +263,11 @@ lines-between-statements = 1
 # Check if files would have been modified, returning a non-zero exit code
 check = false
 
-# Report if files would have been modified, returning a non-zero exit code as well as the difference between the current file and how the formatted file would look like
+# Report the diff between the current file and how it would be formatted,
+# returning a non-zero exit code if changes would be made
 diff = false
 
-# Whether to read the cache.
+# Read the cache to avoid reformatting unchanged files
 no-cache = false
 ```
 

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ regex-index = "^.+$"
 # Allow any naming convention for primary key constraints
 regex-constraint-primary-key = "^.+$"
 
-# ALlow any naming convention for unique keys
+# Allow any naming convention for unique keys
 regex-constraint-unique-key = "^.+$"
 
 # Allow any naming convention for foreign keys
@@ -248,7 +248,7 @@ type-casting-style = "standard"
 # For example, pg_catalog.timezone('UTC', value) is formatted as "value AT TIME ZONE 'UTC'"
 rewrite-function-calls-as-equivalent-syntax = true
 
-# New line before semicolon false
+# Do not place the semicolon on a new line
 new-line-before-semicolon = false
 
 # Remove pg_catalog from functions
@@ -257,13 +257,13 @@ remove-pg-catalog-from-functions = true
 # Remove default index access method (btree)
 remove-default-index-access-method = true
 
-# Separate statements by a certain number by of new line, 1
+# Separate statements by N new lines (default: 1)
 lines-between-statements = 1
 
 # Check if files would have been modified, returning a non-zero exit code
 check = false
 
-# Report if files would have been modified, returning a non-zero exit code as well the difference between the current file and how the formatted file would look like
+# Report if files would have been modified, returning a non-zero exit code as well as the difference between the current file and how the formatted file would look like
 diff = false
 
 # Whether to read the cache.

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -154,10 +154,11 @@ lines-between-statements = 1
 # Check if files would have been modified, returning a non-zero exit code
 check = false
 
-# Report if files would have been modified, returning a non-zero exit code as well as the difference between the current file and how the formatted file would look like
+# Report the diff between the current file and how it would be formatted,
+# returning a non-zero exit code if changes would be made
 diff = false
 
-# Whether to read the cache.
+# Read the cache to avoid reformatting unchanged files
 no-cache = false
 ```
 

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -91,10 +91,10 @@ timestamp-column-suffix = "_at"
 # Suffix Date columns with suffix `_date`
 date-column-suffix = "_date"
 
-# Allow nay naming convention for partitions
+# Allow any naming convention for partitions
 regex-partition = "^.+$"
 
-# Allow all any naming convention for indexes
+# Allow any naming convention for indexes
 regex-index = "^.+$"
 
 # Allow any naming convention for primary key constraints

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -10,6 +10,8 @@ When `PGRUBIC_CONFIG_PATH` environment variable is set, **pgrubic** will first s
 
 If after searching for the configuration file, the configuration file is not found, **pgrubic** will then fall back to the default configuration.
 
+Config values can also be overridden using the `--config <CONFIG_OPTION>` command-line argument.
+
 ## Sections
 
 There are three sections in the configuration file: `global`, `lint` and `format`.
@@ -25,51 +27,137 @@ The `format` section is used to configure format-specific settings for **pgrubic
 <!-- BEGIN GENERATED DEFAULT CONFIG -->
 
 ```toml
+# Path to the cache directory
 cache-dir = ".pgrubic_cache"
+
+# Include all files
 include = []
+
+# Exclude no files
 exclude = []
+
+# Respect gitignore
 respect-gitignore = true
+
 [lint]
+# Target version 14 of PostgreSQL
 target-postgres-version = 14
-additional-non-volatile-functions = []
+
+# Enable all rules
 select = []
+
+# Disable no rules
 ignore = []
+
+# Include all files
 include = []
+
+# Exclude no files
 exclude = []
+
+# Ignore suppressing violations that are marked as `noqa`
 ignore-noqa = false
+
+# List of additional non-volatile functions
+additional-non-volatile-functions = []
+
+# Disallowed schemas
 disallowed-schemas = []
+
+# Allowed extensions
 allowed-extensions = []
+
+# Allowed languages
 allowed-languages = []
+
+# Do not fix violations automatically
 fix = false
+
+# Consider all rules as fixable
 fixable = []
+
+# Consider all rules as fixable
 unfixable = []
+
+# Disallowed data types
 disallowed-data-types = []
+
+# Required columns
 required-columns = []
+
+# Suffix Timestamp columns with `_at`
 timestamp-column-suffix = "_at"
+
+# Suffix Date columns with suffix `_date`
 date-column-suffix = "_date"
+
+# Allow nay naming convention for partitions
 regex-partition = "^.+$"
+
+# Allow all any naming convention for indexes
 regex-index = "^.+$"
+
+# Allow any naming convention for primary key constraints
 regex-constraint-primary-key = "^.+$"
+
+# ALlow any naming convention for unique keys
 regex-constraint-unique-key = "^.+$"
+
+# Allow any naming convention for foreign keys
 regex-constraint-foreign-key = "^.+$"
+
+# Allow any naming convention for check constraints
 regex-constraint-check = "^.+$"
+
+# Allow any naming convention for exclusion constraints
 regex-constraint-exclusion = "^.+$"
+
+# Allow any naming convention for sequences
 regex-sequence = "^.+$"
 
 [format]
+# Include all files
 include = []
+
+# Exclude no files
 exclude = []
+
+# Comma at the beginning of an item
 comma-at-beginning = true
+
+# Compact parenthesized lists margin of 90
 compact-parenthesized-lists-margin = 90
+
+# Uppercase keywords
 uppercase-keywords = true
+
+# Type casting style is standard
+# CAST(value AS type)
 type-casting-style = "standard"
+
+# Rewrite some function calls using their equivalent SQL syntax.
+# For example, pg_catalog.timezone('UTC', value) is formatted as "value AT TIME ZONE 'UTC'"
 rewrite-function-calls-as-equivalent-syntax = true
+
+# New line before semicolon false
 new-line-before-semicolon = false
+
+# Remove pg_catalog from functions
 remove-pg-catalog-from-functions = true
+
+# Remove default index access method (btree)
 remove-default-index-access-method = true
+
+# Separate statements by a certain number by of new line, 1
 lines-between-statements = 1
+
+# Check if files would have been modified, returning a non-zero exit code
 check = false
+
+# Report if files would have been modified, returning a non-zero exit code as well the difference between the current file and how the formatted file would look like
 diff = false
+
+# Whether to read the cache.
 no-cache = false
 ```
 

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -10,7 +10,7 @@ When `PGRUBIC_CONFIG_PATH` environment variable is set, **pgrubic** will first s
 
 If after searching for the configuration file, the configuration file is not found, **pgrubic** will then fall back to the default configuration.
 
-Config values can also be overridden using the `--config <CONFIG_OPTION>` command-line argument.
+Config values can also be overridden using the `--config` command-line argument, which accepts a TOML `<KEY> = <VALUE>` pair and may be repeated, e.g. `--config "lint.target-postgres-version = 17"`.
 
 ## Sections
 
@@ -85,10 +85,10 @@ disallowed-data-types = []
 # Required columns
 required-columns = []
 
-# Suffix Timestamp columns with `_at`
+# Suffix timestamp columns with `_at`
 timestamp-column-suffix = "_at"
 
-# Suffix Date columns with suffix `_date`
+# Suffix date columns with `_date`
 date-column-suffix = "_date"
 
 # Allow any naming convention for partitions

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -100,7 +100,7 @@ regex-index = "^.+$"
 # Allow any naming convention for primary key constraints
 regex-constraint-primary-key = "^.+$"
 
-# ALlow any naming convention for unique keys
+# Allow any naming convention for unique keys
 regex-constraint-unique-key = "^.+$"
 
 # Allow any naming convention for foreign keys
@@ -139,7 +139,7 @@ type-casting-style = "standard"
 # For example, pg_catalog.timezone('UTC', value) is formatted as "value AT TIME ZONE 'UTC'"
 rewrite-function-calls-as-equivalent-syntax = true
 
-# New line before semicolon false
+# Do not place the semicolon on a new line
 new-line-before-semicolon = false
 
 # Remove pg_catalog from functions
@@ -148,13 +148,13 @@ remove-pg-catalog-from-functions = true
 # Remove default index access method (btree)
 remove-default-index-access-method = true
 
-# Separate statements by a certain number by of new line, 1
+# Separate statements by N new lines (default: 1)
 lines-between-statements = 1
 
 # Check if files would have been modified, returning a non-zero exit code
 check = false
 
-# Report if files would have been modified, returning a non-zero exit code as well the difference between the current file and how the formatted file would look like
+# Report if files would have been modified, returning a non-zero exit code as well as the difference between the current file and how the formatted file would look like
 diff = false
 
 # Whether to read the cache.

--- a/src/pgrubic/pgrubic.toml
+++ b/src/pgrubic/pgrubic.toml
@@ -56,10 +56,10 @@ disallowed-data-types = []
 # Required columns
 required-columns = []
 
-# Suffix Timestamp columns with `_at`
+# Suffix timestamp columns with `_at`
 timestamp-column-suffix = "_at"
 
-# Suffix Date columns with suffix `_date`
+# Suffix date columns with `_date`
 date-column-suffix = "_date"
 
 # Allow any naming convention for partitions

--- a/src/pgrubic/pgrubic.toml
+++ b/src/pgrubic/pgrubic.toml
@@ -71,7 +71,7 @@ regex-index = "^.+$"
 # Allow any naming convention for primary key constraints
 regex-constraint-primary-key = "^.+$"
 
-# ALlow any naming convention for unique keys
+# Allow any naming convention for unique keys
 regex-constraint-unique-key = "^.+$"
 
 # Allow any naming convention for foreign keys
@@ -110,7 +110,7 @@ type-casting-style = "standard"
 # For example, pg_catalog.timezone('UTC', value) is formatted as "value AT TIME ZONE 'UTC'"
 rewrite-function-calls-as-equivalent-syntax = true
 
-# New line before semicolon false
+# Do not place the semicolon on a new line
 new-line-before-semicolon = false
 
 # Remove pg_catalog from functions
@@ -119,13 +119,13 @@ remove-pg-catalog-from-functions = true
 # Remove default index access method (btree)
 remove-default-index-access-method = true
 
-# Separate statements by a certain number by of new line, 1
+# Separate statements by N new lines (default: 1)
 lines-between-statements = 1
 
 # Check if files would have been modified, returning a non-zero exit code
 check = false
 
-# Report if files would have been modified, returning a non-zero exit code as well the difference between the current file and how the formatted file would look like
+# Report if files would have been modified, returning a non-zero exit code as well as the difference between the current file and how the formatted file would look like
 diff = false
 
 # Whether to read the cache.

--- a/src/pgrubic/pgrubic.toml
+++ b/src/pgrubic/pgrubic.toml
@@ -1,46 +1,132 @@
+# Path to the cache directory
 cache-dir = ".pgrubic_cache"
+
+# Include all files
 include = []
+
+# Exclude no files
 exclude = []
+
+# Respect gitignore
 respect-gitignore = true
+
 [lint]
+# Target version 14 of PostgreSQL
 target-postgres-version = 14
-additional-non-volatile-functions = []
+
+# Enable all rules
 select = []
+
+# Disable no rules
 ignore = []
+
+# Include all files
 include = []
+
+# Exclude no files
 exclude = []
+
+# Ignore suppressing violations that are marked as `noqa`
 ignore-noqa = false
+
+# List of additional non-volatile functions
+additional-non-volatile-functions = []
+
+# Disallowed schemas
 disallowed-schemas = []
+
+# Allowed extensions
 allowed-extensions = []
+
+# Allowed languages
 allowed-languages = []
+
+# Do not fix violations automatically
 fix = false
+
+# Consider all rules as fixable
 fixable = []
+
+# Consider all rules as fixable
 unfixable = []
+
+# Disallowed data types
 disallowed-data-types = []
+
+# Required columns
 required-columns = []
+
+# Suffix Timestamp columns with `_at`
 timestamp-column-suffix = "_at"
+
+# Suffix Date columns with suffix `_date`
 date-column-suffix = "_date"
+
+# Allow nay naming convention for partitions
 regex-partition = "^.+$"
+
+# Allow all any naming convention for indexes
 regex-index = "^.+$"
+
+# Allow any naming convention for primary key constraints
 regex-constraint-primary-key = "^.+$"
+
+# ALlow any naming convention for unique keys
 regex-constraint-unique-key = "^.+$"
+
+# Allow any naming convention for foreign keys
 regex-constraint-foreign-key = "^.+$"
+
+# Allow any naming convention for check constraints
 regex-constraint-check = "^.+$"
+
+# Allow any naming convention for exclusion constraints
 regex-constraint-exclusion = "^.+$"
+
+# Allow any naming convention for sequences
 regex-sequence = "^.+$"
 
 [format]
+# Include all files
 include = []
+
+# Exclude no files
 exclude = []
+
+# Comma at the beginning of an item
 comma-at-beginning = true
+
+# Compact parenthesized lists margin of 90
 compact-parenthesized-lists-margin = 90
+
+# Uppercase keywords
 uppercase-keywords = true
+
+# Type casting style is standard
+# CAST(value AS type)
 type-casting-style = "standard"
+
+# Rewrite some function calls using their equivalent SQL syntax.
+# For example, pg_catalog.timezone('UTC', value) is formatted as "value AT TIME ZONE 'UTC'"
 rewrite-function-calls-as-equivalent-syntax = true
+
+# New line before semicolon false
 new-line-before-semicolon = false
+
+# Remove pg_catalog from functions
 remove-pg-catalog-from-functions = true
+
+# Remove default index access method (btree)
 remove-default-index-access-method = true
+
+# Separate statements by a certain number by of new line, 1
 lines-between-statements = 1
+
+# Check if files would have been modified, returning a non-zero exit code
 check = false
+
+# Report if files would have been modified, returning a non-zero exit code as well the difference between the current file and how the formatted file would look like
 diff = false
+
+# Whether to read the cache.
 no-cache = false

--- a/src/pgrubic/pgrubic.toml
+++ b/src/pgrubic/pgrubic.toml
@@ -125,8 +125,9 @@ lines-between-statements = 1
 # Check if files would have been modified, returning a non-zero exit code
 check = false
 
-# Report if files would have been modified, returning a non-zero exit code as well as the difference between the current file and how the formatted file would look like
+# Report the diff between the current file and how it would be formatted,
+# returning a non-zero exit code if changes would be made
 diff = false
 
-# Whether to read the cache.
+# Read the cache to avoid reformatting unchanged files
 no-cache = false

--- a/src/pgrubic/pgrubic.toml
+++ b/src/pgrubic/pgrubic.toml
@@ -62,10 +62,10 @@ timestamp-column-suffix = "_at"
 # Suffix Date columns with suffix `_date`
 date-column-suffix = "_date"
 
-# Allow nay naming convention for partitions
+# Allow any naming convention for partitions
 regex-partition = "^.+$"
 
-# Allow all any naming convention for indexes
+# Allow any naming convention for indexes
 regex-index = "^.+$"
 
 # Allow any naming convention for primary key constraints


### PR DESCRIPTION
## Background and Motivation
<!-- Why is this change needed? What problem does it solve? -->
This PR improves configuration documentation by adding inline comments to the default `pgrubic.toml` and propagating the annotated defaults into the README and docs, plus noting that config values can be overridden via `--config`.
## Summary of Changes
<!-- High-level overview of what was changed. -->
- Added descriptive comments to the packaged default configuration (`src/pgrubic/pgrubic.toml`).
- Synced the generated “default config” blocks in `README.md` and `docs/docs/configuration.md` to include those comments.
- Documented CLI overriding of configuration values via `--config <CONFIG_OPTION>`.
## Type of change
<!-- Select the type of change. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Housekeeping (change that does not affect functionality)

## SQL Examples (if applicable)
<!-- Provide sample SQL to show before/after behavior of the linter/formatter. -->

```sql
-- Before
...

-- After
...
```

## Checklist
<!-- Checklist before requesting a review -->
- [x] I have read and followed the [contributing guidelines](https://github.com/bolajiwahab/pgrubic/blob/main/docs/docs/contributing.md)
- [x] I have checked that there are no other open [Pull Requests](https://github.com/bolajiwahab/pgrubic/pulls) for the same update/change
- [x] I have performed a self-review of my code
- [ ] I have added/updated tests (positive + negative cases)
- [ ] I have updated documentation (if applicable)

## Closes / Fixes
<!-- Link issues using keywords: Closes #123, Fixes #456 -->

## Additional information
<!-- Provide any additional information that might be helpful to the reviewer in reviewing this pull request -->
