### PR TITLE
docs: update documentation on no-cache to match current status

### DIFF
--- a/docs/docs/settings.md
+++ b/docs/docs/settings.md
@@ -819,10 +819,14 @@ check = true
 </details>
 
 ### **no-cache**
-Whether to read the cache. Caching helps speed up the formatting process. When a file
-has not been modified after the last formatting, it is simply skipped.
-To force reformatting of a file even if it has not been modified since the last
-formatting, set to `true`.
+Whether to read the cache. Caching speeds up formatting by skipping files whose
+content, format settings, and pgrubic version all match a previous run, since
+re-running the formatter on them would just reproduce what's already on disk.
+
+Set to `true` to bypass the cache and re-run the formatter on every file this run,
+regardless of what the cache says. This does not force a file to be rewritten:
+a file is only ever written when the formatter's output actually differs from
+what's on disk, cache or no cache.
 
 Overridden by the `--no-cache` command-line flag.
 

--- a/src/pgrubic/core/config.py
+++ b/src/pgrubic/core/config.py
@@ -887,10 +887,14 @@ check = true
 </details>
 
 ### **no-cache**
-Whether to read the cache. Caching helps speed up the formatting process. When a file
-has not been modified after the last formatting, it is simply skipped.
-To force reformatting of a file even if it has not been modified since the last
-formatting, set to `true`.
+Whether to read the cache. Caching speeds up formatting by skipping files whose
+content, format settings, and pgrubic version all match a previous run, since
+re-running the formatter on them would just reproduce what's already on disk.
+
+Set to `true` to bypass the cache and re-run the formatter on every file this run,
+regardless of what the cache says. This does not force a file to be rewritten:
+a file is only ever written when the formatter's output actually differs from
+what's on disk, cache or no cache.
 
 Overridden by the `--no-cache` command-line flag.
 


### PR DESCRIPTION
## Background and Motivation
<!-- Why is this change needed? What problem does it solve? -->
Updates the documentation for the `no-cache` formatter setting to reflect current cache behavior and clarify that disabling cache does not imply rewriting unchanged files.

## Summary of Changes
<!-- High-level overview of what was changed. -->
- Clarified `no-cache` semantics: cache is keyed on content + format settings + pgrubic version.
- Documented that `no-cache=true` re-runs formatting on all files but only writes files when output differs.
## Type of change
<!-- Select the type of change. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Housekeeping (change that does not affect functionality)

## SQL Examples (if applicable)
<!-- Provide sample SQL to show before/after behavior of the linter/formatter. -->

```sql
-- Before
...

-- After
...
```

## Checklist
<!-- Checklist before requesting a review -->
- [x] I have read and followed the [contributing guidelines](https://github.com/bolajiwahab/pgrubic/blob/main/docs/docs/contributing.md)
- [x] I have checked that there are no other open [Pull Requests](https://github.com/bolajiwahab/pgrubic/pulls) for the same update/change
- [x] I have performed a self-review of my code
- [ ] I have added/updated tests (positive + negative cases)
- [x] I have updated documentation (if applicable)

## Closes / Fixes
<!-- Link issues using keywords: Closes #123, Fixes #456 -->

## Additional information
<!-- Provide any additional information that might be helpful to the reviewer in reviewing this pull request -->
